### PR TITLE
Add Secure Context

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -45,6 +45,7 @@ spec:dom; type:attribute; text:bubbles
 spec:dom; type:dfn; for:NamedNodeMap; text:element
 spec:dom; type:interface; text:Document
 spec:html; type:attribute; for:HTMLMediaElement; text:readyState
+spec:html; type:dfn; for:/; text:browsing context
 </pre>
 
 # Introduction # {#intro}
@@ -428,6 +429,12 @@ The <a>task source</a> for all the tasks queued in this specification is the
 The API applies only to {{HTMLVideoElement}} in order to start on a minimal
 viable product that has limited security issues. Later versions of this
 specification may allow PIP-ing arbitrary HTML content.
+
+## Secure Context ## {#secure-context}
+
+The API is not limited to [[SECURE-CONTEXTS]] because it exposes a feature
+to web applications that user agents usually offer natively on all media
+regardless of the <a>browsing context</a>.
 
 ## Feature Policy ## {#feature-policy}
 


### PR DESCRIPTION
@yoavweiss suggested adding one section for Secure Context that explains why API is not restricted to Secure Context.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/picture-in-picture/pull/105.html" title="Last updated on Nov 26, 2018, 12:15 PM GMT (2456bcd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/picture-in-picture/105/ed25bd1...2456bcd.html" title="Last updated on Nov 26, 2018, 12:15 PM GMT (2456bcd)">Diff</a>