### PR TITLE
Update spec info to point to Media WG

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Contributions to this repository are intended to become part of Recommendation-track documents
 governed by the [W3C Patent Policy](http://www.w3.org/Consortium/Patent-Policy-20040205/) and
-[Document License](http://www.w3.org/Consortium/Legal/copyright-documents). To contribute, you must
+[Software and Document License](http://www.w3.org/Consortium/Legal/copyright-software). To contribute, you must
 either participate in the relevant W3C Working Group or make a non-member patent licensing
  commitment.
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,2 +1,2 @@
-All documents in this Repository are licensed by contributors under the [W3C Document
-License](http://www.w3.org/Consortium/Legal/copyright-documents).
+All documents in this Repository are licensed by contributors under the [W3C
+Software and Document License](https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document).

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Picture-in-Picture (PiP) ![](https://storage.googleapis.com/material-icons/external-assets/v4/icons/svg/ic_picture_in_picture_alt_black_24px.svg) 
 
-[![Build Status](https://travis-ci.org/WICG/picture-in-picture.svg?branch=master)](https://travis-ci.org/WICG/picture-in-picture)
+[![Build Status](https://travis-ci.org/w3c/picture-in-picture.svg?branch=master)](https://travis-ci.org/w3c/picture-in-picture)
 [![WPT Chrome](https://wpt-badge.glitch.me/?product=chrome&prefix=/picture-in-picture/)](https://wpt.fyi/results/picture-in-picture)
 [![WPT Edge](https://wpt-badge.glitch.me/?product=edge&prefix=/picture-in-picture/)](https://wpt.fyi/results/picture-in-picture)
 [![WPT Firefox](https://wpt-badge.glitch.me/?product=firefox&prefix=/picture-in-picture/)](https://wpt.fyi/results/picture-in-picture)
 [![WPT Safari](https://wpt-badge.glitch.me/?product=safari&prefix=/picture-in-picture/)](https://wpt.fyi/results/picture-in-picture)
 
-https://wicg.github.io/picture-in-picture
+https://w3c.github.io/picture-in-picture
 
 This standardization project aims to provide APIs to allow websites to create a floating video window over the desktop.
 

--- a/index.bs
+++ b/index.bs
@@ -2,12 +2,12 @@
 Title: Picture-in-Picture
 Shortname: picture-in-picture
 Level: 1
-Status: CG-DRAFT
-ED: https://wicg.github.io/picture-in-picture
+Status: ED
+ED: https://w3c.github.io/picture-in-picture
 Favicon: https://raw.githubusercontent.com/google/material-design-icons/master/action/2x_web/ic_picture_in_picture_alt_black_48dp.png
-Group: WICG
+Group: mediawg
 Markup Shorthands: markdown yes
-Repository: wicg/picture-in-picture
+Repository: w3c/picture-in-picture
 !Web Platform Tests: <a href="https://github.com/web-platform-tests/wpt/tree/master/feature-policy">feature-policy/</a><br/><a href="https://github.com/web-platform-tests/wpt/tree/master/picture-in-picture">picture-in-picture/</a>
 Editor: François Beaufort, w3cid 81174, Google LLC https://www.google.com, fbeaufort@google.com
 Editor: Mounir Lamouri, w3cid 45389, Google LLC https://www.google.com, mlamouri@google.com

--- a/security-privacy-questionnaire.md
+++ b/security-privacy-questionnaire.md
@@ -42,7 +42,7 @@ No.
 **Does this specification allow an origin access to aspects of a user’s local
 computing environment?**
 
-[`pictureInPictureEnabled`](https://wicg.github.io/picture-in-picture/#dom-document-pictureinpictureenabled)
+[`pictureInPictureEnabled`](https://w3c.github.io/picture-in-picture/#dom-document-pictureinpictureenabled)
 will reflect the state of the  "Picture-in-Picture" setting on the system or 
 user agent.
 
@@ -76,7 +76,7 @@ No.
 **Does this specification have a "Security Considerations" and
 "Privacy Considerations" section?**
 
-https://wicg.github.io/picture-in-picture/#security-considerations
+https://w3c.github.io/picture-in-picture/#security-considerations
 
 **Does this specification allow downgrading default security characteristics?**
 

--- a/w3c.json
+++ b/w3c.json
@@ -1,5 +1,5 @@
  {
-    "group":      ["115198"]
+    "group":      115198
 ,   "contacts":   ["tidoust", "jernoble", "mounirlamouri"]
 ,   "shortName":  "picture-in-picture"
 }

--- a/w3c.json
+++ b/w3c.json
@@ -1,5 +1,5 @@
  {
-    "group":      ["80485"]
-,   "contacts":   ["marcoscaceres"]
+    "group":      ["115198"]
+,   "contacts":   ["tidoust", "jernoble", "mounirlamouri"]
 ,   "shortName":  "picture-in-picture"
 }


### PR DESCRIPTION
- Update spec boilerplate (copyright, SOTD) to note Media WG ownership
- Update self-references from `wicg.github.io` to `w3c.github.io`
- Update `w3c.json` info
- Update document license to that used by the Media WG

Note the PR depends on https://github.com/tabatkins/bikeshed/pull/1498
... and should only be merged once the repo has been transferred to the W3C organization (#150)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tidoust/picture-in-picture/pull/157.html" title="Last updated on Jul 24, 2019, 2:34 PM UTC (4f373b0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/picture-in-picture/157/75d9c66...tidoust:4f373b0.html" title="Last updated on Jul 24, 2019, 2:34 PM UTC (4f373b0)">Diff</a>