### PR TITLE
Add explicit [Exposed]

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -426,6 +426,7 @@ The {{pictureInPictureElement}} attribute's getter must run these steps:
 ## Interface <code>PictureInPictureWindow</code> ## {#interface-picture-in-picture-window}
 
 <xmp class="idl">
+[Exposed=Window]
 interface PictureInPictureWindow : EventTarget {
   readonly attribute long width;
   readonly attribute long height;


### PR DESCRIPTION
Required after heycam/webidl#423. (Found from web-platform-tests/wpt#18382)

`<xmp>` is deprecated BTW, mind replacing them with `<pre>`?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/saschanaz/picture-in-picture/pull/164.html" title="Last updated on Aug 23, 2019, 3:33 AM UTC (a4d0de9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/picture-in-picture/164/882677c...saschanaz:a4d0de9.html" title="Last updated on Aug 23, 2019, 3:33 AM UTC (a4d0de9)">Diff</a>