### PR TITLE
Fix cross-spec links and references

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -487,11 +487,10 @@ specification may allow PIP-ing arbitrary HTML content.
 
 ## Feature Policy ## {#feature-policy}
 
-This specification defines a <a>policy-controlled feature</a> that controls
-whether the <a>request Picture-in-Picture algorithm</a> may return a
-{{SecurityError}} and whether {{pictureInPictureEnabled}} is `true` or `false`.
-
-The feature name for this feature is `"picture-in-picture"`.
+This specification defines a <a>policy-controlled feature</a> named
+`"picture-in-picture"` that controls whether the <a>request Picture-in-Picture
+algorithm</a> may return a {{SecurityError}} and whether
+{{pictureInPictureEnabled}} is `true` or `false`.
 
 The <a>default allowlist</a> for this feature is `*`.
 

--- a/index.bs
+++ b/index.bs
@@ -3,7 +3,7 @@ Title: Picture-in-Picture
 Shortname: picture-in-picture
 Level: 1
 Status: ED
-ED: https://w3c.github.io/picture-in-picture
+ED: https://w3c.github.io/picture-in-picture/
 Favicon: https://raw.githubusercontent.com/google/material-design-icons/master/action/2x_web/ic_picture_in_picture_alt_black_48dp.png
 Group: mediawg
 Markup Shorthands: markdown yes
@@ -18,18 +18,8 @@ Abstract: content sites, or applications on their device.
 </pre>
 
 <pre class="anchors">
-spec: Feature Policy; urlPrefix: https://wicg.github.io/feature-policy/#
-    type: dfn
-        text: default allowlist
-        text: feature name
-        text: policy-controlled feature
 spec: HTML; urlPrefix: https://html.spec.whatwg.org/multipage/
     type: dfn
-        urlPrefix: infrastructure.html
-            text: in parallel
-            text: reflect
-        urlPrefix: interaction.html
-            text: triggered by user activation
         urlPrefix: media.html
             text: media element event task source
 spec: Remote-Playback; urlPrefix: https://w3c.github.io/remote-playback/#dfn-
@@ -183,7 +173,7 @@ run the following steps:
 
 1. If <a>Picture-in-Picture support</a> is `false`, throw a
     {{NotSupportedError}} and abort these steps.
-2. If the document is not allowed to use the <a>policy-controlled feature</a>
+2. If the document is not <a>allowed to use</a> the <a>policy-controlled feature</a>
     named `"picture-in-picture"`, throw a {{SecurityError}} and abort these
     steps.
 3. If |video|'s {{readyState}} attribute is {{HAVE_NOTHING}}, throw a
@@ -192,9 +182,9 @@ run the following steps:
     these steps.
 5. OPTIONALLY, if the {{disablePictureInPicture}} attribute is present on
     |video|, throw an {{InvalidStateError}} and abort these steps.
-6. If |userActivationRequired| is `true` and the algorithm is not
-    <a>triggered by user activation</a>, throw a {{NotAllowedError}} and
-    abort these steps.
+6. If |userActivationRequired| is `true` and the <a>relevant global object</a>
+    of <a>this</a> does not have <a>transient activation</a>, throw a
+    {{NotAllowedError}} and abort these steps.
 7. If |video| is {{pictureInPictureElement}}, abort these steps.
 8. If |playingRequired| is `true` and |video| is {{paused}}, abort these steps.
 9. Set {{pictureInPictureElement}} to |video|.
@@ -203,7 +193,7 @@ run the following steps:
 11. <a>Queue a task</a> to <a>fire an event</a> with the name
     {{enterpictureinpicture}} using {{EnterPictureInPictureEvent}} at the
     |video| with its {{bubbles}} attribute initialized to `true` and its
-    {{pictureInPictureWindow}} attribute initialized to
+    {{EnterPictureInPictureEvent/pictureInPictureWindow}} attribute initialized to
     <a>Picture-in-Picture window</a>.
 
 It is RECOMMENDED that video frames are not rendered in the page and in the
@@ -437,18 +427,18 @@ interface PictureInPictureWindow : EventTarget {
 
 A {{PictureInPictureWindow}} instance represents a <a>Picture-in-Picture
 window</a> associated with an {{HTMLVideoElement}}. When instantiated, an
-instance of {{PictureInPictureWindow}} has its |state| set to |opened|.
+instance of {{PictureInPictureWindow}} has its |state| set to `opened`.
 
 When the <dfn>close window algorithm</dfn> with an instance of
-{{PictureInPictureWindow}} is invoked, its |state| is set to |closed|.
+{{PictureInPictureWindow}} is invoked, its |state| is set to `closed`.
 
 The {{width}} attribute MUST return the width in <a lt=px value>CSS pixels</a> of the
 <a>Picture-in-Picture window</a> associated with {{pictureInPictureElement}} if
-the |state| is |opened|. Otherwise, it MUST return 0.
+the |state| is `opened`. Otherwise, it MUST return 0.
 
 The {{height}} attribute MUST return the height in <a lt=px value>CSS pixels</a> of the
 <a>Picture-in-Picture window</a> associated with {{pictureInPictureElement}} if
-the |state| is |opened|. Otherwise, it MUST return 0.
+the |state| is `opened`. Otherwise, it MUST return 0.
 
 When the size of the <a>Picture-in-Picture window</a> associated with
 {{pictureInPictureElement}} changes, the user agent MUST <a>queue a task</a> to
@@ -501,7 +491,7 @@ This specification defines a <a>policy-controlled feature</a> that controls
 whether the <a>request Picture-in-Picture algorithm</a> may return a
 {{SecurityError}} and whether {{pictureInPictureEnabled}} is `true` or `false`.
 
-The <a>feature name</a> for this feature is `"picture-in-picture"`.
+The feature name for this feature is `"picture-in-picture"`.
 
 The <a>default allowlist</a> for this feature is `*`.
 


### PR DESCRIPTION
Minor editorial updates to fix a few broken links and correct references:
- Drop custom definitions that are no longer needed
- Replace "triggered by user activation" with new user activation model (see https://github.com/whatwg/html/issues/5129)
- Use back ticks for values instead of var shorthand
- Drop link to feature name in Feature Policy (term no longer exists)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tidoust/picture-in-picture/pull/174.html" title="Last updated on Jan 14, 2020, 4:34 PM UTC (f4b4902)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/picture-in-picture/174/4db5e80...tidoust:f4b4902.html" title="Last updated on Jan 14, 2020, 4:34 PM UTC (f4b4902)">Diff</a>