### PR TITLE
Rename CSS pseudo-class :picture-in-picture

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -473,9 +473,15 @@ The <a>task source</a> for all the tasks queued in this specification is the
 
 ## CSS pseudo-class ## {#css-pseudo-class}
 
-The `:picture-in-picture` <a>pseudo-class</a> MUST match the Picture-in-Picture
-element. It is different from the {{pictureInPictureElement}} as it does NOT
-apply to the shadow host chain.
+The `:picture-in-picture-inline` <a>pseudo-class</a> MUST match the
+Picture-in-Picture element. It is different from the {{pictureInPictureElement}}
+as it does NOT apply to the shadow host chain.
+
+Note: Previous version of this specification used the name `:picture-in-picture`
+for this <a>pseudo-class</a>. This name has been <em>deprecated</em> because it
+was too vague. Web developers may have thought that this <a>pseudo-class</a>
+would apply to the element in the Picture-in-Picture window, whereas it applies
+to the element in the web page.
 
 # Security considerations # {#security-considerations}
 


### PR DESCRIPTION
As Discussed during the [Media WG call on 12 May 2020](https://www.w3.org/2020/05/12-mediawg-minutes.html#t01), this PR renames CSS pseudo-class `:picture-in-picture` to `:picture-in-picture-inline`

@mounirlamouri @jernoble @tidoust 

Fix: https://github.com/w3c/picture-in-picture/issues/172


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/picture-in-picture/pull/181.html" title="Last updated on May 19, 2020, 12:47 PM UTC (53ed1ab)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/picture-in-picture/181/9a28dfa...53ed1ab.html" title="Last updated on May 19, 2020, 12:47 PM UTC (53ed1ab)">Diff</a>