### PR TITLE
Remove recommendation for minimum and maximum PiP window

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -211,10 +211,6 @@ Styles applied to |video| (such as opacity, visibility, transform, etc.) MUST
 NOT apply in the Picture-in-Picture window. Its aspect ratio is based on the
 video size.
 
-It is also RECOMMENDED that the Picture-in-Picture window has a maximum and
-minimum size. For example, it could be restricted to be between a quarter and
-a half of one dimension of the screen.
-
 ## Exit Picture-in-Picture ## {#exit-pip}
 
 When the <dfn>exit Picture-in-Picture algorithm</dfn> is invoked,


### PR DESCRIPTION
Remove recommendation for minimum and maximum size PiP window restrictions/limitations.

There is no apparent reason for the recommendation for restricting/limiting PiP window size.

PiP window is an application to `getDisplayMedia()`. If the user wants to capture PiP window, and adjust the pixel dimensions to arbitrary sizes, they should be able to do so without arbitrary restrictions.

Note. Am **_not_** a W3C member, so their "IPR" bells and whistles will probably go off for this PR. The gist is clear. Someone with appropriate clearance can delete the language and push the change.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/guest271314/picture-in-picture/pull/186.html" title="Last updated on Jun 11, 2020, 1:55 PM UTC (fd0615b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/picture-in-picture/186/0b4bff1...guest271314:fd0615b.html" title="Last updated on Jun 11, 2020, 1:55 PM UTC (fd0615b)">Diff</a>