### PR TITLE
fix: check HTMLVideoElement/disablePictureInPicture attribute

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -181,8 +181,8 @@ run the following steps:
     {{InvalidStateError}} and abort these steps.
 4. If |video| has no video track, throw a {{InvalidStateError}} and abort
     these steps.
-5. OPTIONALLY, if the {{disablePictureInPicture}} attribute is present on
-    |video|, throw an {{InvalidStateError}} and abort these steps.
+5. OPTIONALLY, if |video|'s {{HTMLVideoElement/disablePictureInPicture}} is true,
+    throw an {{InvalidStateError}} and abort these steps.
 6. If |userActivationRequired| is `true` and the <a>relevant global object</a>
     of <a>this</a> does not have <a>transient activation</a>, throw a
     {{NotAllowedError}} and abort these steps.


### PR DESCRIPTION
closes #156 
closes #144

The check is not that "attribute is present", but that it has been set to "true"... the IDL attribute is always present, and always initializes to false. 

```
x = document.createElement("video")
x.disablePictureInPicture; // false
```
