### PR TITLE
Rename Feature Policy to Permissions Policy

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -9,7 +9,7 @@ Favicon: https://raw.githubusercontent.com/google/material-design-icons/master/a
 Group: mediawg
 Markup Shorthands: markdown yes
 Repository: w3c/picture-in-picture
-!Web Platform Tests: <a href="https://github.com/web-platform-tests/wpt/tree/master/feature-policy">feature-policy/</a><br/><a href="https://github.com/web-platform-tests/wpt/tree/master/picture-in-picture">picture-in-picture/</a>
+!Web Platform Tests: <a href="https://github.com/web-platform-tests/wpt/tree/master/permissions-policy">permissions-policy/</a><br/><a href="https://github.com/web-platform-tests/wpt/tree/master/picture-in-picture">picture-in-picture/</a>
 Editor: François Beaufort, w3cid 81174, Google LLC https://www.google.com, fbeaufort@google.com
 Editor: Mounir Lamouri, w3cid 45389, Google LLC https://www.google.com, mlamouri@google.com
 Abstract: This specification intends to provide APIs to allow websites to
@@ -505,7 +505,7 @@ The API is not limited to [[SECURE-CONTEXTS]] because it exposes a feature
 to web applications that user agents usually offer natively on all media
 regardless of the <a>browsing context</a>.
 
-## Feature Policy ## {#feature-policy}
+## Permissions Policy ## {#permissions-policy}
 
 This specification defines a <a>policy-controlled feature</a> named
 `"picture-in-picture"` that controls whether the <a>request Picture-in-Picture


### PR DESCRIPTION
Feature Policy has been renamed, and the spec has moved. This change
updates the integration to use the new name.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/clelland/picture-in-picture/pull/196.html" title="Last updated on Oct 20, 2020, 5:22 PM UTC (f198a40)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/picture-in-picture/196/a92d952...clelland:f198a40.html" title="Last updated on Oct 20, 2020, 5:22 PM UTC (f198a40)">Diff</a>