### PR TITLE
Rename default branch to "main"

### DIFF
--- a/.github/workflows/pr-push.yml
+++ b/.github/workflows/pr-push.yml
@@ -12,7 +12,7 @@ on:
   # manually from GitHub's UI.
   pull_request: {}
   push:
-    branches: [master]
+    branches: [main]
   workflow_dispatch:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Picture-in-Picture (PiP) ![](https://storage.googleapis.com/material-icons/external-assets/v4/icons/svg/ic_picture_in_picture_alt_black_24px.svg) 
 
-[![Build Status](https://travis-ci.org/w3c/picture-in-picture.svg?branch=master)](https://travis-ci.org/w3c/picture-in-picture)
 [![WPT Chrome](https://wpt-badge.glitch.me/?product=chrome&prefix=/picture-in-picture/)](https://wpt.fyi/results/picture-in-picture)
 [![WPT Firefox](https://wpt-badge.glitch.me/?product=firefox&prefix=/picture-in-picture/)](https://wpt.fyi/results/picture-in-picture)
 [![WPT Safari](https://wpt-badge.glitch.me/?product=safari&prefix=/picture-in-picture/)](https://wpt.fyi/results/picture-in-picture)

--- a/index.bs
+++ b/index.bs
@@ -5,7 +5,6 @@ Level: None
 Status: ED
 ED: https://w3c.github.io/picture-in-picture/
 TR: https://www.w3.org/TR/picture-in-picture/
-Previous Version: from biblio
 Favicon: https://raw.githubusercontent.com/google/material-design-icons/master/action/2x_web/ic_picture_in_picture_alt_black_48dp.png
 Group: mediawg
 Markup Shorthands: markdown yes


### PR DESCRIPTION
Also drop the link to the "build passing" icon on Travis CI since we're no longer using Travis CI. No new icon that could replace that for now.

Context for the renaming: https://www.w3.org/2021/04/13-mediawg-minutes.html#t03

@beaufortfrancois Default branch name obviously needs to be updated before that PR gets merged! Happy to take care of that.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/picture-in-picture/pull/203.html" title="Last updated on May 4, 2021, 3:33 PM UTC (cdabbfc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/picture-in-picture/203/8703d25...cdabbfc.html" title="Last updated on May 4, 2021, 3:33 PM UTC (cdabbfc)">Diff</a>