### PR TITLE
turn condition

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -93,9 +93,9 @@ extensible.
     // Picture-in-Picture for the video, otherwise leave it.
     try {
       if (document.pictureInPictureElement) {
-        await video.requestPictureInPicture();
-      } else {
         await document.exitPictureInPicture();
+      } else {
+        await video.requestPictureInPicture();
       }
     } catch (err) {
       // Video failed to enter/leave Picture-in-Picture mode.


### PR DESCRIPTION
If `document.pictureInPictureElement` is true, PinP is enable and can run `document.exitPictureInPicture()` .


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/youkinjoh/picture-in-picture/pull/205.html" title="Last updated on Aug 26, 2021, 1:34 AM UTC (ce7b332)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/picture-in-picture/205/1e8297a...youkinjoh:ce7b332.html" title="Last updated on Aug 26, 2021, 1:34 AM UTC (ce7b332)">Diff</a>