### PR TITLE
Add the UA slot 'initiators of active Picture-in-Picture sessions'

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -186,33 +186,31 @@ run the following steps:
 
 1. If <a>Picture-in-Picture support</a> is `false`, throw a
     {{NotSupportedError}} and abort these steps.
-2. Let |document| be the <a>current settings object</a>'s <a>relevant global object</a>'s
-    <a>associated <code>Document</code></a>.
-3. If the |document| is not <a>allowed to use</a> the <a>policy-controlled feature</a>
+2. If the document is not <a>allowed to use</a> the <a>policy-controlled feature</a>
     named `"picture-in-picture"`, throw a {{SecurityError}} and abort these
     steps.
-4. If |video|'s {{readyState}} attribute is {{HAVE_NOTHING}}, throw a
+3. If |video|'s {{readyState}} attribute is {{HAVE_NOTHING}}, throw a
     {{InvalidStateError}} and abort these steps.
-5. If |video| has no video track, throw a {{InvalidStateError}} and abort
+4. If |video| has no video track, throw a {{InvalidStateError}} and abort
     these steps.
-6. OPTIONALLY, if |video|'s {{HTMLVideoElement/disablePictureInPicture}} is true,
+5. OPTIONALLY, if |video|'s {{HTMLVideoElement/disablePictureInPicture}} is true,
     throw an {{InvalidStateError}} and abort these steps.
-7. If |userActivationRequired| is `true` and the <a>relevant global object</a>
+6. If |userActivationRequired| is `true` and the <a>relevant global object</a>
     of <a>this</a> does not have <a>transient activation</a>, throw a
     {{NotAllowedError}} and abort these steps.
-8. If |video| is {{pictureInPictureElement}}, abort these steps.
-9. If |playingRequired| is `true` and |video| is {{paused}}, abort these steps.
-10. Set {{pictureInPictureElement}} to |video|.
-11. Let <dfn>Picture-in-Picture window</dfn> be a new instance of
+7. If |video| is {{pictureInPictureElement}}, abort these steps.
+8. If |playingRequired| is `true` and |video| is {{paused}}, abort these steps.
+9. Set {{pictureInPictureElement}} to |video|.
+10. Let <dfn>Picture-in-Picture window</dfn> be a new instance of
     {{PictureInPictureWindow}} associated with {{pictureInPictureElement}}.
-12. Append <a>relevant settings object</a>'s <a>origin</a> to
+11. Append <a>relevant settings object</a>'s <a>origin</a> to
     <a>initiators of active Picture-in-Picture sessions</a>.
-13. <a>Queue a task</a> to <a>fire an event</a> with the name
+12. <a>Queue a task</a> to <a>fire an event</a> with the name
     {{enterpictureinpicture}} using {{PictureInPictureEvent}} at the
     |video| with its {{bubbles}} attribute initialized to `true` and its
     {{PictureInPictureEvent/pictureInPictureWindow}} attribute initialized to
     <a>Picture-in-Picture window</a>.
-14. If {{pictureInPictureElement}} is <a>fullscreenElement</a>, it is
+13. If {{pictureInPictureElement}} is <a>fullscreenElement</a>, it is
     RECOMMENDED to <a>exit fullscreen</a>.
 
 It is RECOMMENDED that video frames are not rendered in the page and in the

--- a/index.bs
+++ b/index.bs
@@ -176,7 +176,7 @@ extensible.
 A <a>user agent</a> has:
 
 1. An <dfn>initiators of active Picture-in-Picture sessions</dfn>
-    set of zero or more {{Document}} objects, which is initially empty.
+    set of zero or more <a>origins</a>, which is initially empty.
 
 ## Request Picture-in-Picture ## {#request-pip}
 
@@ -205,7 +205,8 @@ run the following steps:
 10. Set {{pictureInPictureElement}} to |video|.
 11. Let <dfn>Picture-in-Picture window</dfn> be a new instance of
     {{PictureInPictureWindow}} associated with {{pictureInPictureElement}}.
-12. Append |document| to <a>initiators of active Picture-in-Picture sessions</a>.
+12. Append <a>relevant settings object</a>'s <a>origin</a> to
+    <a>initiators of active Picture-in-Picture sessions</a>.
 13. <a>Queue a task</a> to <a>fire an event</a> with the name
     {{enterpictureinpicture}} using {{PictureInPictureEvent}} at the
     |video| with its {{bubbles}} attribute initialized to `true` and its
@@ -247,9 +248,8 @@ the user agent MUST run the following steps:
     {{PictureInPictureEvent/pictureInPictureWindow}} attribute initialized to
     <a>Picture-in-Picture window</a> associated with {{pictureInPictureElement}}.
 4. Unset {{pictureInPictureElement}}.
-5. Let |document| be the <a>current settings object</a>'s <a>relevant global object</a>'s
-    <a>associated <code>Document</code></a>.
-6. Remove |document| from <a>initiators of active Picture-in-Picture sessions</a>.
+5. Remove the <a>relevant settings object</a>'s <a>origin</a> from
+    <a>initiators of active Picture-in-Picture sessions</a>.
 
 It is NOT RECOMMENDED that the video playback state changes when the <a>exit
 Picture-in-Picture algorithm</a> is invoked. The website SHOULD be in control

--- a/index.bs
+++ b/index.bs
@@ -171,12 +171,12 @@ extensible.
 
 # Concepts # {#concepts}
 
-## Internal Slot Definitions
+## Internal Slot Definitions ## {#defines}
 
 A <a>user agent</a> has:
 
-1. an <dfn>initiators of active Picture-in-Picture sessions</dfn> set,
-    which is initially empty.
+1. An <dfn>initiators of active Picture-in-Picture sessions</dfn>
+    set of zero or more {{Document}} objects, which is initially empty.
 
 ## Request Picture-in-Picture ## {#request-pip}
 

--- a/index.bs
+++ b/index.bs
@@ -171,6 +171,13 @@ extensible.
 
 # Concepts # {#concepts}
 
+## Internal Slot Definitions
+
+A <a>user agent</a> has:
+
+1. an <dfn>initiators of active Picture-in-Picture sessions</dfn> set,
+    which is initially empty.
+
 ## Request Picture-in-Picture ## {#request-pip}
 
 When the <dfn>request Picture-in-Picture algorithm</dfn> with |video|,
@@ -179,29 +186,32 @@ run the following steps:
 
 1. If <a>Picture-in-Picture support</a> is `false`, throw a
     {{NotSupportedError}} and abort these steps.
-2. If the document is not <a>allowed to use</a> the <a>policy-controlled feature</a>
+2. Let |document| be the <a>current settings object</a>'s <a>relevant global object</a>'s
+    <a>associated <code>Document</code></a>.
+3. If the |document| is not <a>allowed to use</a> the <a>policy-controlled feature</a>
     named `"picture-in-picture"`, throw a {{SecurityError}} and abort these
     steps.
-3. If |video|'s {{readyState}} attribute is {{HAVE_NOTHING}}, throw a
+4. If |video|'s {{readyState}} attribute is {{HAVE_NOTHING}}, throw a
     {{InvalidStateError}} and abort these steps.
-4. If |video| has no video track, throw a {{InvalidStateError}} and abort
+5. If |video| has no video track, throw a {{InvalidStateError}} and abort
     these steps.
-5. OPTIONALLY, if |video|'s {{HTMLVideoElement/disablePictureInPicture}} is true,
+6. OPTIONALLY, if |video|'s {{HTMLVideoElement/disablePictureInPicture}} is true,
     throw an {{InvalidStateError}} and abort these steps.
-6. If |userActivationRequired| is `true` and the <a>relevant global object</a>
+7. If |userActivationRequired| is `true` and the <a>relevant global object</a>
     of <a>this</a> does not have <a>transient activation</a>, throw a
     {{NotAllowedError}} and abort these steps.
-7. If |video| is {{pictureInPictureElement}}, abort these steps.
-8. If |playingRequired| is `true` and |video| is {{paused}}, abort these steps.
-9. Set {{pictureInPictureElement}} to |video|.
-10. Let <dfn>Picture-in-Picture window</dfn> be a new instance of
+8. If |video| is {{pictureInPictureElement}}, abort these steps.
+9. If |playingRequired| is `true` and |video| is {{paused}}, abort these steps.
+10. Set {{pictureInPictureElement}} to |video|.
+11. Let <dfn>Picture-in-Picture window</dfn> be a new instance of
     {{PictureInPictureWindow}} associated with {{pictureInPictureElement}}.
-11. <a>Queue a task</a> to <a>fire an event</a> with the name
+12. Append |document| to <a>initiators of active Picture-in-Picture sessions</a>.
+13. <a>Queue a task</a> to <a>fire an event</a> with the name
     {{enterpictureinpicture}} using {{PictureInPictureEvent}} at the
     |video| with its {{bubbles}} attribute initialized to `true` and its
     {{PictureInPictureEvent/pictureInPictureWindow}} attribute initialized to
     <a>Picture-in-Picture window</a>.
-12. If {{pictureInPictureElement}} is <a>fullscreenElement</a>, it is
+14. If {{pictureInPictureElement}} is <a>fullscreenElement</a>, it is
     RECOMMENDED to <a>exit fullscreen</a>.
 
 It is RECOMMENDED that video frames are not rendered in the page and in the
@@ -237,6 +247,9 @@ the user agent MUST run the following steps:
     {{PictureInPictureEvent/pictureInPictureWindow}} attribute initialized to
     <a>Picture-in-Picture window</a> associated with {{pictureInPictureElement}}.
 4. Unset {{pictureInPictureElement}}.
+5. Let |document| be the <a>current settings object</a>'s <a>relevant global object</a>'s
+    <a>associated <code>Document</code></a>.
+6. Remove |document| from <a>initiators of active Picture-in-Picture sessions</a>.
 
 It is NOT RECOMMENDED that the video playback state changes when the <a>exit
 Picture-in-Picture algorithm</a> is invoked. The website SHOULD be in control

--- a/index.bs
+++ b/index.bs
@@ -176,7 +176,14 @@ extensible.
 A <a>user agent</a> has:
 
 1. An <dfn>initiators of active Picture-in-Picture sessions</dfn>
-    set of zero or more <a>origins</a>, which is initially empty.
+    list of zero or more <a>origins</a>, which is initially empty.
+
+Note: In case a <a>user agent</a> supports multiple Picture-in-Picture
+  windows, the list allows duplicates.
+
+An origin is said to have an <dfn>active Picture-in-Picture session</dfn> if any
+of the origins in <a>initiators of active Picture-in-Picture sessions</a>
+are <a>same origin-domain</a> with origin.
 
 ## Request Picture-in-Picture ## {#request-pip}
 
@@ -246,7 +253,7 @@ the user agent MUST run the following steps:
     {{PictureInPictureEvent/pictureInPictureWindow}} attribute initialized to
     <a>Picture-in-Picture window</a> associated with {{pictureInPictureElement}}.
 4. Unset {{pictureInPictureElement}}.
-5. Remove the <a>relevant settings object</a>'s <a>origin</a> from
+5. Remove one <a>item</a> matching <a>relevant settings object</a>'s <a>origin</a> from
     <a>initiators of active Picture-in-Picture sessions</a>.
 
 It is NOT RECOMMENDED that the video playback state changes when the <a>exit


### PR DESCRIPTION
Add the internal UA slot 'initiators of active Picture-in-Picture sessions'

This allows other specs, like Compute Pressure, to know if a document
currently has an active Picture-in-Picture session.

This is related to https://github.com/WICG/compute-pressure/issues/83


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kenchris/picture-in-picture/pull/210.html" title="Last updated on Mar 22, 2022, 8:28 AM UTC (4349ce6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/picture-in-picture/210/fb22039...kenchris:4349ce6.html" title="Last updated on Mar 22, 2022, 8:28 AM UTC (4349ce6)">Diff</a>