### PR TITLE
Align event firing with DOM suggested phrasing

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -212,7 +212,7 @@ run the following steps:
     {{PictureInPictureWindow}} associated with {{pictureInPictureElement}}.
 11. Append <a>relevant settings object</a>'s <a>origin</a> to
     <a>initiators of active Picture-in-Picture sessions</a>.
-12. <a>Queue a task</a> to <a>fire an event</a> with the name
+12. <a>Queue a task</a> to <a>fire an event</a> named
     {{enterpictureinpicture}} using {{PictureInPictureEvent}} at the
     |video| with its {{bubbles}} attribute initialized to `true` and its
     {{PictureInPictureEvent/pictureInPictureWindow}} attribute initialized to
@@ -247,7 +247,7 @@ the user agent MUST run the following steps:
     abort these steps.
 2. Run the <a>close window algorithm</a> with the <a>Picture-in-Picture
     window</a> associated with {{pictureInPictureElement}}.
-3. <a>Queue a task</a> to <a>fire an event</a> with the name
+3. <a>Queue a task</a> to <a>fire an event</a> named
     {{leavepictureinpicture}} using {{PictureInPictureEvent}} at the
     |video| with its {{bubbles}} attribute initialized to `true` and its
     {{PictureInPictureEvent/pictureInPictureWindow}} attribute initialized to
@@ -475,7 +475,7 @@ the |state| is `opened`. Otherwise, it MUST return 0.
 
 When the size of the <a>Picture-in-Picture window</a> associated with
 {{pictureInPictureElement}} changes, the user agent MUST <a>queue a task</a> to
-<a>fire an event</a> with the name {{resize}} at {{pictureInPictureElement}}.
+<a>fire an event</a> named {{resize}} at {{pictureInPictureElement}}.
 
 ## Event types ## {#event-types}
 


### PR DESCRIPTION
See https://dom.spec.whatwg.org/#firing-events-example


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dontcallmedom/picture-in-picture/pull/212.html" title="Last updated on Jun 8, 2022, 3:38 PM UTC (11dfefc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/picture-in-picture/212/58be154...dontcallmedom:11dfefc.html" title="Last updated on Jun 8, 2022, 3:38 PM UTC (11dfefc)">Diff</a>