### PR TITLE
Add Chrome for Android support

### DIFF
--- a/implementation-status.md
+++ b/implementation-status.md
@@ -5,23 +5,23 @@ This document shows the current implementation status of Picture-in-Picture on t
 
 Work is still in progress in [Chrome Canary](http://chrome.com/canary):
 
-* The API has shipped in Chrome 70 for **Linux, macOS, and Windows** and Chrome 72 for **Chrome OS**.
+* The API has shipped in Chrome 70 for **Linux, macOS, and Windows**, Chrome 72 for **Chrome OS**, and Chrome 105 for **Android**.
 * Know where to [report Picture-in-Picture bugs](https://bugs.chromium.org/p/chromium/issues/entry?components=Blink>Media>PictureInPicture).
 * Root [Issue 806249](http://crbug.com/806249) and blocking issues are most authorative on status.
 
 Feature/Platform                       | Desktop | Android |
 -------------------------------------- | :-----: | :-----: |
-`video.requestPictureInPicture()`      | 68      |         |
-`video.onenterpictureinpicture`        | 68      |         |
-`video.onleavepictureinpicture`        | 68      |         |
-`video.disablePictureInPicture`        | 68      |         |
-`document.pictureInPictureEnabled`     | 68      |         |
-`document.pictureInPictureElement`     | 68      |         |
-`document.exitPictureInPicture()`      | 68      |         |
-`PictureInPictureWindow.width\|height` | 68      |         |
-`PictureInPictureWindow.onresize`      | 68      |         |
+`video.requestPictureInPicture()`      | 68      |  105    |
+`video.onenterpictureinpicture`        | 68      |  105    |
+`video.onleavepictureinpicture`        | 68      |  105    |
+`video.disablePictureInPicture`        | 68      |  105    |
+`document.pictureInPictureEnabled`     | 68      |  105    |
+`document.pictureInPictureElement`     | 68      |  105    |
+`document.exitPictureInPicture()`      | 68      |  105    |
+`PictureInPictureWindow.width\|height` | 68      |  105    |
+`PictureInPictureWindow.onresize`      | 68      |  105    |
 `video.autoPictureInPicture`           | 👷      |         |
-Media Session controls support         | 74      |         |
+Media Session controls support         | 74      |  105    |
 
 Tip: Chrome channel releases are tracked at [https://googlechromelabs.github.io/current-versions/](https://googlechromelabs.github.io/current-versions/).
 


### PR DESCRIPTION
Following https://groups.google.com/a/chromium.org/g/blink-dev/c/jXkQiIVpxr8, Picture-in-Picture support is about to be enabled on Chrome on Android.

FYI @liberato-at-chromium