### PR TITLE
Remove autoPictureInPicture HTMLVideoElement attribute

### DIFF
--- a/implementation-status.md
+++ b/implementation-status.md
@@ -20,7 +20,6 @@ Feature/Platform                       | Desktop | Android |
 `document.exitPictureInPicture()`      | 68      |  105    |
 `PictureInPictureWindow.width\|height` | 68      |  105    |
 `PictureInPictureWindow.onresize`      | 68      |  105    |
-`video.autoPictureInPicture`           | 👷      |         |
 Media Session controls support         | 74      |  105    |
 
 Tip: Chrome channel releases are tracked at [https://googlechromelabs.github.io/current-versions/](https://googlechromelabs.github.io/current-versions/).

--- a/index.bs
+++ b/index.bs
@@ -187,9 +187,8 @@ are <a>same origin-domain</a> with origin.
 
 ## Request Picture-in-Picture ## {#request-pip}
 
-When the <dfn>request Picture-in-Picture algorithm</dfn> with |video|,
-|userActivationRequired| and |playingRequired| is invoked, the user agent MUST
-run the following steps:
+When the <dfn>request Picture-in-Picture algorithm</dfn> with |video| is invoked,
+the user agent MUST run the following steps:
 
 1. If <a>Picture-in-Picture support</a> is `false`, throw a
     {{NotSupportedError}} and abort these steps.
@@ -202,22 +201,21 @@ run the following steps:
     these steps.
 5. OPTIONALLY, if |video|'s {{HTMLVideoElement/disablePictureInPicture}} is true,
     throw an {{InvalidStateError}} and abort these steps.
-6. If |userActivationRequired| is `true` and the <a>relevant global object</a>
+6. If {{pictureInPictureElement}} is `null` and the <a>relevant global object</a>
     of <a>this</a> does not have <a>transient activation</a>, throw a
     {{NotAllowedError}} and abort these steps.
 7. If |video| is {{pictureInPictureElement}}, abort these steps.
-8. If |playingRequired| is `true` and |video| is {{paused}}, abort these steps.
-9. Set {{pictureInPictureElement}} to |video|.
-10. Let <dfn>Picture-in-Picture window</dfn> be a new instance of
-    {{PictureInPictureWindow}} associated with {{pictureInPictureElement}}.
-11. Append <a>relevant settings object</a>'s <a>origin</a> to
+8. Set {{pictureInPictureElement}} to |video|.
+9. Let <dfn>Picture-in-Picture window</dfn> be a new instance of
+   {{PictureInPictureWindow}} associated with {{pictureInPictureElement}}.
+10. Append <a>relevant settings object</a>'s <a>origin</a> to
     <a>initiators of active Picture-in-Picture sessions</a>.
-12. <a>Queue a task</a> to <a>fire an event</a> named
+11. <a>Queue a task</a> to <a>fire an event</a> named
     {{enterpictureinpicture}} using {{PictureInPictureEvent}} at the
     |video| with its {{bubbles}} attribute initialized to `true` and its
     {{PictureInPictureEvent/pictureInPictureWindow}} attribute initialized to
     <a>Picture-in-Picture window</a>.
-13. If {{pictureInPictureElement}} is <a>fullscreenElement</a>, it is
+12. If {{pictureInPictureElement}} is <a>fullscreenElement</a>, it is
     RECOMMENDED to <a>exit fullscreen</a>.
 
 It is RECOMMENDED that video frames are not rendered in the page and in the
@@ -269,8 +267,8 @@ Picture-in-Picture algorithm</a>.
 
 Some pages may want to disable Picture-in-Picture mode for a video element; for
 example, they may want to prevent the user agent from suggesting a
-Picture-in-Picture context menu or to request Picture-in-Picture automatically
-in some cases. To support these use cases, a new {{disablePictureInPicture}}
+Picture-in-Picture context menu in some cases.
+To support these use cases, a new {{disablePictureInPicture}}
 attribute is added to the list of content attributes for video elements.
 
 The {{disablePictureInPicture}} IDL attribute MUST <a>reflect</a> the content
@@ -287,43 +285,6 @@ the user agent SHOULD run these steps:
     method with {{InvalidStateError}}.
 2. If |video| is {{pictureInPictureElement}}, run the <a>exit
     Picture-in-Picture algorithm</a>.
-
-## Auto Picture-in-Picture ## {#auto-pip}
-
-Some pages may want to automatically enter and leave Picture-in-Picture for
-a video element; for example, video meeting web apps would benefit from
-some automatic Picture-in-Picture behavior when the user switches back and forth
-between the web app and other applications/tabs.
-To support these use cases, a new {{autoPictureInPicture}} attribute is
-added to the list of content attributes for video elements.
-
-The {{autoPictureInPicture}} IDL attribute MUST <a>reflect</a> the content
-attribute of the same name.
-
-The <dfn>autoPictureInPictureElement</dfn> is the video element, among all
-video elements with the {{autoPictureInPicture}} attribute currently set,
-whose {{autoPictureInPicture}} attribute was set most recently. Note that the
-<a>autoPictureInPictureElement</a> can have the {{disablePictureInPicture}}
-attribute set. In that case, as expected, it won't be allowed to enter
-Picture-in-Picture mode in the <a>request Picture-in-Picture algorithm</a>.
-
-When the visibility state of a <a>top-level browsing context</a> value
-switches from "visible" to "hidden", the user agent MAY run these steps:
-
-1. If <a>autoPictureInPictureElement</a> is `null`, abort these steps.
-2. If {{pictureInPictureElement}} is set, abort these steps.
-3. Let |video| be <a>autoPictureInPictureElement</a>.
-4. Let |userActivationRequired| be `false`.
-5. Let |playingRequired| be `true`.
-6. Run the <a>request Picture-in-Picture algorithm</a> with |video|,
-    |userActivationRequired|, and |playingRequired|.
-
-When the visibility state of a <a>top-level browsing context</a> value
-switches from "hidden" to "visible", the user agent MAY run these steps:
-
-1. If <a>autoPictureInPictureElement</a> is `null`, abort these steps.
-2. If {{pictureInPictureElement}} is <a>autoPictureInPictureElement</a>, run
-    the <a>exit Picture-in-Picture algorithm</a>.
 
 ## Interaction with Fullscreen ## {#fullscreen}
 
@@ -381,7 +342,6 @@ partial interface HTMLVideoElement {
   attribute EventHandler onenterpictureinpicture;
   attribute EventHandler onleavepictureinpicture;
 
-  [CEReactions] attribute boolean autoPictureInPicture;
   [CEReactions] attribute boolean disablePictureInPicture;
 };
 </pre>
@@ -391,14 +351,10 @@ return <a>a new promise</a> |promise| and run the following steps <a>in
 parallel</a>:
 
 1. Let |video| be the video element on which the method was invoked.
-2. Let |userActivationRequired| be `true` if {{pictureInPictureElement}} is
-    `null`. It is `false` otherwise.
-3. Let |playingRequired| be `false`.
-4. Run the <a>request Picture-in-Picture algorithm</a> with |video|,
-    |userActivationRequired|, and |playingRequired|.
-5. If the previous step threw an exception, reject |promise| with that
+2. Run the <a>request Picture-in-Picture algorithm</a> with |video|.
+3. If the previous step threw an exception, reject |promise| with that
     exception and abort these steps.
-6. Return |promise| with the <a>Picture-in-Picture window</a> associated with
+4. Return |promise| with the <a>Picture-in-Picture window</a> associated with
     {{pictureInPictureElement}}.
 
 ## Extensions to <code>Document</code> ## {#document-extensions}

--- a/index.bs
+++ b/index.bs
@@ -207,7 +207,7 @@ the user agent MUST run the following steps:
 7. If |video| is {{pictureInPictureElement}}, abort these steps.
 8. Set {{pictureInPictureElement}} to |video|.
 9. Let <dfn>Picture-in-Picture window</dfn> be a new instance of
-   {{PictureInPictureWindow}} associated with {{pictureInPictureElement}}.
+    {{PictureInPictureWindow}} associated with {{pictureInPictureElement}}.
 10. Append <a>relevant settings object</a>'s <a>origin</a> to
     <a>initiators of active Picture-in-Picture sessions</a>.
 11. <a>Queue a task</a> to <a>fire an event</a> named


### PR DESCRIPTION
This PR is about removing the `autoPictureInPicture` HTMLVideoElement attribute from the spec. The only browser that implemented it for experimental purposes was Chrome and it never shipped.

@steimelchrome PTAL


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/picture-in-picture/pull/216.html" title="Last updated on Dec 6, 2022, 4:56 AM UTC (082ab8f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/picture-in-picture/216/0d2dac0...082ab8f.html" title="Last updated on Dec 6, 2022, 4:56 AM UTC (082ab8f)">Diff</a>