### PR TITLE
Remove Page Visibility spec references

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -25,7 +25,6 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/multipage/
             text: media element event task source
     type: dfn
         urlPrefix: interaction.html
-            text: traversable navigable
             text: system visibility state
 spec: Fullscreen; urlPrefix: https://fullscreen.spec.whatwg.org
     type: dfn; text: fullscreen flag; url: #fullscreen-flag
@@ -314,7 +313,7 @@ window.
 
 The Picture-in-Picture window visibility MUST NOT be taken into account by the
 user agent to determine if the <a>system visibility state</a> of a 
-<a>traversable navigable</a> has changed.
+<a for="/">traversable navigable</a> has changed.
 
 ## One Picture-in-Picture window ## {#one-pip-window}
 


### PR DESCRIPTION
@rakuco Thanks for filing https://github.com/w3c/picture-in-picture/issues/217

Hopefully this PR fixes it. Can you have a look?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/picture-in-picture/pull/218.html" title="Last updated on Dec 19, 2022, 2:51 PM UTC (b9df8a2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/picture-in-picture/218/a4e812a...b9df8a2.html" title="Last updated on Dec 19, 2022, 2:51 PM UTC (b9df8a2)">Diff</a>