### PR TITLE
Update the spec and explainer to clarify scope

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -33,7 +33,6 @@ Many users want to continue consuming media while they interact with other conte
 ### For future considerations or candidates for first API
 
 *   The API will take a hint for the preferred window size and position which could be ignored by the user agent.
-*   The API may be extended to allow an arbitrary element of the DOM to enter Picture-in-Picture.
 *   The API may be extended to allow custom actions in the window UI.
 
 ## Proposed API

--- a/index.bs
+++ b/index.bs
@@ -56,7 +56,7 @@ window stays visible even when the user agent is not visible.
 Picture-in-Picture is a common platform-level feature among desktop and mobile
 OSs.
 
-This specification extends {{HTMLVideoElement}} with the aim of allowing websites
+This specification extends {{HTMLVideoElement}} allowing websites
 to initiate and control this behavior by exposing the following sets of properties:
 
 * Notify the website when it enters and leaves Picture-in-Picture mode.
@@ -67,8 +67,6 @@ to initiate and control this behavior by exposing the following sets of properti
 * Allow the website to exit Picture-in-Picture mode.
 * Allow the website to check if Picture-in-Picture mode can be triggered.
 
-The Picture-in-Picture API is very similar to [[Fullscreen]] as they
-have similar properties.
 
 # Examples # {#examples}
 
@@ -467,7 +465,7 @@ apply to the shadow host chain.
 
 <em>This section is non-normative.</em>
 
-To prevent potential abuse through spoofing, the API applies only to
+To limit potential abuse through spoofing, the API applies only to
 {{HTMLVideoElement}}. User interaction with the Picture-in-Picture window
 is intentionally limited so that the only effect is on the Picture-in-Picture
 window itself or the media being played.

--- a/index.bs
+++ b/index.bs
@@ -12,7 +12,7 @@ Repository: w3c/picture-in-picture
 !Web Platform Tests: <a href="https://github.com/web-platform-tests/wpt/tree/master/permissions-policy">permissions-policy/</a><br/><a href="https://github.com/web-platform-tests/wpt/tree/master/picture-in-picture">picture-in-picture/</a>
 Editor: François Beaufort, w3cid 81174, Google LLC https://www.google.com, fbeaufort@google.com
 Former Editor: Mounir Lamouri, w3cid 45389, Google LLC https://www.google.com, mlamouri@google.com
-Abstract: This specification intends to provide APIs to allow websites to
+Abstract: This specification provides APIs to allow websites to
 Abstract: create a floating video window always on top of other windows so that
 Abstract: users may continue consuming media while they interact with other
 Abstract: content sites, or applications on their device.
@@ -56,8 +56,8 @@ window stays visible even when the user agent is not visible.
 Picture-in-Picture is a common platform-level feature among desktop and mobile
 OSs.
 
-This specification aims to allow websites to initiate and control this behavior
-by exposing the following sets of properties to the API:
+This specification extends {{HTMLVideoElement}} with the aim of allowing websites
+to initiate and control this behavior by exposing the following sets of properties:
 
 * Notify the website when it enters and leaves Picture-in-Picture mode.
 * Allow the website to trigger Picture-in-Picture mode via a user gesture on a
@@ -67,10 +67,8 @@ by exposing the following sets of properties to the API:
 * Allow the website to exit Picture-in-Picture mode.
 * Allow the website to check if Picture-in-Picture mode can be triggered.
 
-The proposed Picture-in-Picture API is very similar to [[Fullscreen]] as they
-have similar properties. The API only applies to
-{{HTMLVideoElement}} at the moment but is meant to be
-extensible.
+The Picture-in-Picture API is very similar to [[Fullscreen]] as they
+have similar properties.
 
 # Examples # {#examples}
 

--- a/index.bs
+++ b/index.bs
@@ -467,9 +467,10 @@ apply to the shadow host chain.
 
 <em>This section is non-normative.</em>
 
-The API applies only to {{HTMLVideoElement}} in order to start on a minimal
-viable product that has limited security issues. Later versions of this
-specification may allow PIP-ing arbitrary HTML content.
+To prevent potential abuse through spoofing, the API applies only to
+{{HTMLVideoElement}}. User interaction with the picture in picture window
+is intentionally limited so that the only effect is on the picture in
+picture window itself or the media being played.
 
 ## Secure Context ## {#secure-context}
 

--- a/index.bs
+++ b/index.bs
@@ -468,9 +468,9 @@ apply to the shadow host chain.
 <em>This section is non-normative.</em>
 
 To prevent potential abuse through spoofing, the API applies only to
-{{HTMLVideoElement}}. User interaction with the picture in picture window
-is intentionally limited so that the only effect is on the picture in
-picture window itself or the media being played.
+{{HTMLVideoElement}}. User interaction with the Picture-in-Picture window
+is intentionally limited so that the only effect is on the Picture-in-Picture
+window itself or the media being played.
 
 ## Secure Context ## {#secure-context}
 


### PR DESCRIPTION
In response to https://github.com/w3c/picture-in-picture/issues/182, this clarifies that the goal for this API doesn't include arbitrary HTML content, and is scoped to HTMLVideoElement.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/picture-in-picture/pull/221.html" title="Last updated on May 2, 2024, 1:04 PM UTC (66ba36d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/picture-in-picture/221/e2c0312...66ba36d.html" title="Last updated on May 2, 2024, 1:04 PM UTC (66ba36d)">Diff</a>