### PR TITLE
Fix bikeshed errors

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -39,9 +39,12 @@ spec: Remote-Playback; urlPrefix: https://w3c.github.io/remote-playback/#dfn-
 <pre class="link-defaults">
 spec:dom; type:attribute; text:bubbles
 spec:dom; type:dfn; for:NamedNodeMap; text:element
+spec:dom; type:dfn; text:origin
 spec:dom; type:interface; text:Document
 spec:html; type:attribute; for:HTMLMediaElement; text:readyState
 spec:html; type:dfn; for:/; text:browsing context
+spec:infra; type:dfn; text:user agent
+spec:infra; type:dfn; for:list; text:item
 </pre>
 
 # Introduction # {#intro}
@@ -178,7 +181,7 @@ A <a>user agent</a> has:
 Note: In case a <a>user agent</a> supports multiple Picture-in-Picture
   windows, the list allows duplicates.
 
-An origin is said to have an <dfn>active Picture-in-Picture session</dfn> if any
+An origin is said to have an active Picture-in-Picture session if any
 of the origins in <a>initiators of active Picture-in-Picture sessions</a>
 are <a>same origin-domain</a> with origin.
 
@@ -364,7 +367,7 @@ partial interface Document {
 </pre>
 
 The {{pictureInPictureEnabled}} attribute's getter must return `true` if
-<a>Picture-in-Picture support</a> is `true` and the <a>context object</a> is
+<a>Picture-in-Picture support</a> is `true` and <a>this</a>> is
 <a>allowed to use</a> the feature indicated by attribute name
 `picture-in-picture`, and `false` otherwise.
 
@@ -390,11 +393,11 @@ partial interface mixin DocumentOrShadowRoot {
 
 The {{pictureInPictureElement}} attribute's getter must run these steps:
 
-1. If the <a>context object</a> is not <a>connected</a>, return `null` and abort
-    these steps.
+1. If <a>this</a> is a <a for=/>shadow root</a> and its <a for=DocumentFragment>host</a>
+    is not <a>connected</a>, return `null` and abort these steps.
 2. Let |candidate| be the result of <a>retargeting</a> Picture-in-Picture
-    element against the <a>context object</a>.
-3. If |candidate| and the <a>context object</a> are in the same <a>tree</a>,
+    element against <a>this</a>.
+3. If |candidate| and <a>this</a> are in the same <a>tree</a>,
     return |candidate| and abort these steps.
 4. Return `null`.
 


### PR DESCRIPTION
This PR fixes the following bikeshed errors:

```
LINK ERROR: Multiple possible 'user agent' dfn refs.
Arbitrarily chose https://infra.spec.whatwg.org/#user-agent
To auto-select one of the following refs, insert one of these lines into a &lt;pre class=link-defaults> block:
spec:infra; type:dfn; text:user agent
spec:reporting-1; type:dfn; text:user agent
The following refs show up multiple times in their spec, in a way that Bikeshed can't distinguish between. Either create a manual link, or ask the spec maintainer to add disambiguating attributes (usually a for='' attribute to all of them).
spec:css2; type:dfn; for:/; text:user agent
  https://www.w3.org/TR/CSS21/conform.html#ua
  https://www.w3.org/TR/CSS21/conform.html#user-agent
&lt;a bs-line-number="173" data-link-type="dfn" data-lt="user agent">user agent&lt;/a>
LINK ERROR: Multiple possible 'origins' dfn refs.
Arbitrarily chose https://dom.spec.whatwg.org/#concept-document-origin
To auto-select one of the following refs, insert one of these lines into a &lt;pre class=link-defaults> block:
spec:dom; type:dfn; text:origin
spec:fetch; type:dfn; text:origin
spec:html; type:dfn; for:/; text:origin
spec:html; type:dfn; for:environment settings object; text:origin
spec:url; type:dfn; text:origin
spec:service-workers; type:dfn; text:origin
spec:fenced-frame; type:dfn; for:exfiltration budget metadata; text:origin
spec:fenced-frame; type:dfn; for:exfiltration budget metadata reference; text:origin
spec:prefetch; type:dfn; text:origin
&lt;a bs-line-number="176" data-link-type="dfn" data-lt="origins">origins&lt;/a>
LINK ERROR: Multiple possible 'user agent' dfn refs.
Arbitrarily chose https://infra.spec.whatwg.org/#user-agent
To auto-select one of the following refs, insert one of these lines into a &lt;pre class=link-defaults> block:
spec:infra; type:dfn; text:user agent
spec:reporting-1; type:dfn; text:user agent
The following refs show up multiple times in their spec, in a way that Bikeshed can't distinguish between. Either create a manual link, or ask the spec maintainer to add disambiguating attributes (usually a for='' attribute to all of them).
spec:css2; type:dfn; for:/; text:user agent
  https://www.w3.org/TR/CSS21/conform.html#ua
  https://www.w3.org/TR/CSS21/conform.html#user-agent
&lt;a bs-line-number="178" data-link-type="dfn" data-lt="user agent">user agent&lt;/a>
LINK ERROR: Multiple possible 'origin' dfn refs.
Arbitrarily chose https://dom.spec.whatwg.org/#concept-document-origin
To auto-select one of the following refs, insert one of these lines into a &lt;pre class=link-defaults> block:
spec:dom; type:dfn; text:origin
spec:fetch; type:dfn; text:origin
spec:html; type:dfn; for:/; text:origin
spec:html; type:dfn; for:environment settings object; text:origin
spec:url; type:dfn; text:origin
spec:service-workers; type:dfn; text:origin
spec:fenced-frame; type:dfn; for:exfiltration budget metadata; text:origin
spec:fenced-frame; type:dfn; for:exfiltration budget metadata reference; text:origin
spec:prefetch; type:dfn; text:origin
&lt;a bs-line-number="208" data-link-type="dfn" data-lt="origin">origin&lt;/a>
LINK ERROR: Multiple possible 'item' dfn refs.
Arbitrarily chose https://infra.spec.whatwg.org/#list-item
To auto-select one of the following refs, insert one of these lines into a &lt;pre class=link-defaults> block:
spec:infra; type:dfn; for:list; text:item
spec:infra; type:dfn; for:stack; text:item
spec:infra; type:dfn; for:queue; text:item
spec:infra; type:dfn; for:set; text:item
spec:infra; type:dfn; for:struct; text:item
spec:infra; type:dfn; for:tuple; text:item
&lt;a bs-line-number="251" data-link-type="dfn" data-lt="item">item&lt;/a>
LINK ERROR: Multiple possible 'origin' dfn refs.
Arbitrarily chose https://dom.spec.whatwg.org/#concept-document-origin
To auto-select one of the following refs, insert one of these lines into a &lt;pre class=link-defaults> block:
spec:dom; type:dfn; text:origin
spec:fetch; type:dfn; text:origin
spec:html; type:dfn; for:/; text:origin
spec:html; type:dfn; for:environment settings object; text:origin
spec:url; type:dfn; text:origin
spec:service-workers; type:dfn; text:origin
spec:fenced-frame; type:dfn; for:exfiltration budget metadata; text:origin
spec:fenced-frame; type:dfn; for:exfiltration budget metadata reference; text:origin
spec:prefetch; type:dfn; text:origin
&lt;a bs-line-number="251" data-link-type="dfn" data-lt="origin">origin&lt;/a>
LINK ERROR: No 'dfn' refs found for 'context object' that are marked for export.
&lt;a bs-line-number="367" data-link-type="dfn" data-lt="context object">context object&lt;/a>
LINK ERROR: No 'dfn' refs found for 'context object' that are marked for export.
&lt;a bs-line-number="393" data-link-type="dfn" data-lt="context object">context object&lt;/a>
LINK ERROR: No 'dfn' refs found for 'context object' that are marked for export.
&lt;a bs-line-number="396" data-link-type="dfn" data-lt="context object">context object&lt;/a>
LINK ERROR: No 'dfn' refs found for 'context object' that are marked for export.
&lt;a bs-line-number="397" data-link-type="dfn" data-lt="context object">context object&lt;/a>
Unexported dfn that's not referenced locally - did you mean to export it?
&lt;dfn bs-line-number="181" data-dfn-type="dfn" id="active-picture-in-picture-session" data-lt="active Picture-in-Picture session" data-noexport="by-default" class="dfn-paneled">active Picture-in-Picture session&lt;/dfn>
```

FIX https://github.com/w3c/picture-in-picture/issues/234


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/picture-in-picture/pull/235.html" title="Last updated on Sep 30, 2024, 11:43 AM UTC (1e1dc11)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/picture-in-picture/235/e819c96...1e1dc11.html" title="Last updated on Sep 30, 2024, 11:43 AM UTC (1e1dc11)">Diff</a>