### PR TITLE
Expand permissions policy to include auto-pip

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -493,7 +493,13 @@ whether picture-in-picture is allowed:
 
 <dl dfn-type=value>
   <dt>"<dfn permission export>picture-in-picture</dfn>".
+  <dd>
+    The `"picture-in-picture"` permission policy.
+
   <dt>"<dfn permission export>automatic-picture-in-picture</dfn>".
+
+  <dd>
+    The `"automatic-picture-in-picture"` permission policy.
 </dl>
 
 Access to the Picture-in-Picture API is gated behind the

--- a/index.bs
+++ b/index.bs
@@ -34,10 +34,6 @@ spec: Remote-Playback; urlPrefix: https://w3c.github.io/remote-playback/#dfn-
     type: dfn
         text: local playback device
         text: local playback state
-spec: MediaSession; urlPrefix: https://w3c.github.io/mediasession
-    type: dfn; text: enterpictureinpicture; url: #dom-mediasessionaction-enterpictureinpicture
-    type: dfn; text: contentoccluded; url: #dom-mediasessionenterpictureinpicturereason-contentoccluded
-    type: dfn; text: media session action; url: #media-session-action
 </pre>
 
 <pre class="link-defaults">
@@ -308,10 +304,10 @@ Picture-in-Picture.
 The API will have to be used with the [[MediaSession]] API for customizing the
 available controls on the Picture-in-Picture window.
 
-The user agent SHOULD not override the <a>media session action</a>
-<a>enterpictureinpicture</a> action handler,  if one is provided by the site.
-This gives the site control over the Picture-in-Picture user experience, when a
-Picture-in-Picture window is requested.
+The user agent SHOULD not override the media session action
+{{MediaSessionAction/"enterpictureinpicture"}} action handler,  if one is
+provided by the site. This gives the site control over the Picture-in-Picture
+user experience, when a Picture-in-Picture window is requested.
 
 ## Interaction with Page Visibility ## {#page-visibility}
 
@@ -497,22 +493,28 @@ whether picture-in-picture is allowed:
 <dl dfn-type=value>
   <dt>"<dfn permission export>picture-in-picture</dfn>".
   <dd>
-    The `"picture-in-picture"` permission policy.
+    Controls whether the document is allowed to use Picture-in-Picture.
+    Specifically, the <a>request Picture-in-Picture algorithm</a> throws a
+    {{SecurityError}} if the document is not [=allowed to use=] this feature.
+    The <a>default allowlist</a> for this feature is `*`.
 
   <dt>"<dfn permission export>automatic-picture-in-picture</dfn>".
   <dd>
-    The `"automatic-picture-in-picture"` permission policy.
+    Controls whether the user agent SHOULD automatically trigger
+    Picture-in-Picture. The <a>default allowlist</a> for this feature is
+    `self`.
 </dl>
 
 Access to the Picture-in-Picture API is gated behind the
 <a>policy-controlled feature</a> {{picture-in-picture}}, which has a
 <a>default allowlist</a> of `*`.
 
-When the document is not <a>allowed to use</a> the
+When the document is not [=allowed to use=] the
 <a>policy-controlled feature</a> named {{automatic-picture-in-picture}}, the
-user agent SHOULD not trigger a [[MediaSession]] <a>enterpictureinpicture</a>
-action with the <a>contentoccluded</a> reason. The <a>default allowlist</a> for
-this feature is `self`.
+user agent SHOULD not trigger a [[MediaSession]]
+{{MediaSessionAction/"enterpictureinpicture"}} action with the
+{{MediaSessionEnterPictureInPictureReason/"contentoccluded"}} reason. The
+<a>default allowlist</a> for this feature is `self`.
 
 Note: User agents should surface a console warning whenever
 `"picture-in-picture"` is blocked by the {{automatic-picture-in-picture}}

--- a/index.bs
+++ b/index.bs
@@ -305,7 +305,7 @@ The API will have to be used with the [[MediaSession]] API for customizing the
 available controls on the Picture-in-Picture window.
 
 The user agent SHOULD not override the media session action
-{{MediaSessionAction/"enterpictureinpicture"}} action handler,  if one is
+{{MediaSessionAction/"enterpictureinpicture"}} action handler, if one is
 provided by the site. This gives the site control over the Picture-in-Picture
 user experience, when a Picture-in-Picture window is requested.
 
@@ -493,10 +493,8 @@ whether picture-in-picture is allowed:
 <dl dfn-type=value>
   <dt>"<dfn permission export>picture-in-picture</dfn>".
   <dd>
-    Controls whether the document is allowed to use Picture-in-Picture.
-    Specifically, the <a>request Picture-in-Picture algorithm</a> throws a
-    {{SecurityError}} if the document is not [=allowed to use=] this feature.
-    The <a>default allowlist</a> for this feature is `*`.
+    Controls whether the [=document=] [=allowed to use|is allowed=] to use
+    Picture-in-Picture. The <a>default allowlist</a> for this feature is `*`.
 
   <dt>"<dfn permission export>automatic-picture-in-picture</dfn>".
   <dd>

--- a/index.bs
+++ b/index.bs
@@ -46,6 +46,7 @@ spec:dom; type:dfn; for:NamedNodeMap; text:element
 spec:dom; type:dfn; text:origin
 spec:dom; type:interface; text:Document
 spec:html; type:attribute; for:HTMLMediaElement; text:readyState
+spec:html; type:dfn; text:allowed to use
 spec:html; type:dfn; for:/; text:browsing context
 spec:infra; type:dfn; text:user agent
 spec:infra; type:dfn; for:list; text:item
@@ -197,8 +198,8 @@ the user agent MUST run the following steps:
 1. If <a>Picture-in-Picture support</a> is `false`, throw a
     {{NotSupportedError}} and abort these steps.
 2. If the document is not <a>allowed to use</a> the <a>policy-controlled feature</a>
-    named {{picture-in-picture}} or {{automatic-picture-in-picture}}, throw a
-    {{SecurityError}} and abort these steps.
+    named `"picture-in-picture"`, throw a {{SecurityError}} and abort these
+    steps.
 3. If |video|'s {{readyState}} attribute is {{HAVE_NOTHING}}, throw a
     {{InvalidStateError}} and abort these steps.
 4. If |video| has no video track, throw a {{InvalidStateError}} and abort
@@ -309,6 +310,8 @@ available controls on the Picture-in-Picture window.
 
 The user agent SHOULD not override the <a>media session action</a>
 <a>enterpictureinpicture</a> action handler,  if one is provided by the site.
+This gives the site control over the Picture-in-Picture user experience, when a
+Picture-in-Picture window is requested.
 
 ## Interaction with Page Visibility ## {#page-visibility}
 
@@ -497,7 +500,6 @@ whether picture-in-picture is allowed:
     The `"picture-in-picture"` permission policy.
 
   <dt>"<dfn permission export>automatic-picture-in-picture</dfn>".
-
   <dd>
     The `"automatic-picture-in-picture"` permission policy.
 </dl>
@@ -506,10 +508,11 @@ Access to the Picture-in-Picture API is gated behind the
 <a>policy-controlled feature</a> {{picture-in-picture}}, which has a
 <a>default allowlist</a> of `*`.
 
-When the {{automatic-picture-in-picture}} <a>policy-controlled feature</a>
-policy is set, the user agent SHOULD not trigger a [[MediaSession]]
-<a>enterpictureinpicture</a> action with the <a>contentoccluded</a> reason. The
-<a>default allowlist</a> for this feature is `self`.
+When the document is not <a>allowed to use</a> the
+<a>policy-controlled feature</a> named {{automatic-picture-in-picture}}, the
+user agent SHOULD not trigger a [[MediaSession]] <a>enterpictureinpicture</a>
+action with the <a>contentoccluded</a> reason. The <a>default allowlist</a> for
+this feature is `self`.
 
 Note: User agents should surface a console warning whenever
 `"picture-in-picture"` is blocked by the {{automatic-picture-in-picture}}
@@ -518,5 +521,5 @@ permissions policy.
 # Acknowledgments # {#acknowledgments}
 
 Thanks to Jennifer Apacible, Zouhir Chahoud, Marcos Cáceres, Philip Jägenstedt,
-Jeremy Jones, Chris Needham, Jer Noble, Justin Uberti, Yoav Weiss, and Eckhart
-Wörner for their contributions to this document.
+Jeremy Jones, Chris Needham, Jer Noble, Justin Uberti, Yoav Weiss, Eckhart
+Wörner and Benjamin Keen for their contributions to this document.

--- a/index.bs
+++ b/index.bs
@@ -481,12 +481,22 @@ regardless of the <a>browsing context</a>.
 
 ## Permissions Policy ## {#permissions-policy}
 
-This specification defines a <a>policy-controlled feature</a> named
-`"picture-in-picture"` that controls whether the <a>request Picture-in-Picture
-algorithm</a> may return a {{SecurityError}} and whether
-{{pictureInPictureEnabled}} is `true` or `false`.
+This specification defines two <a>policy-controlled features</a> that control
+whether picture-in-picture is allowed:
 
+* `"picture-in-picture"`.
+* `"browser-initiated-automatic-picture-in-picture"`.
+
+The <a>policy-controlled feature</a> named `"picture-in-picture"` controls
+whether the <a>request Picture-in-Picture algorithm</a> may return a
+{{SecurityError}} and whether {{pictureInPictureEnabled}} is `true` or `false`.
 The <a>default allowlist</a> for this feature is `*`.
+
+The <a>policy-controlled feature</a> named
+`"browser-initiated-automatic-picture-in-picture"` controls whether the
+<a>request Picture-in-Picture algorithm</a> may be invoked automatically by the
+<a>user agent</a>. When blocked by this policy, a console warning is recorded.
+The <a>default allowlist</a> for this feature is `self`.
 
 # Acknowledgments # {#acknowledgments}
 

--- a/index.bs
+++ b/index.bs
@@ -485,18 +485,17 @@ This specification defines two <a>policy-controlled features</a> that control
 whether picture-in-picture is allowed:
 
 * `"picture-in-picture"`.
-* `"browser-initiated-automatic-picture-in-picture"`.
+* `"automatic-picture-in-picture"`.
 
 The <a>policy-controlled feature</a> named `"picture-in-picture"` controls
 whether the <a>request Picture-in-Picture algorithm</a> may return a
 {{SecurityError}} and whether {{pictureInPictureEnabled}} is `true` or `false`.
 The <a>default allowlist</a> for this feature is `*`.
 
-The <a>policy-controlled feature</a> named
-`"browser-initiated-automatic-picture-in-picture"` controls whether the
-<a>request Picture-in-Picture algorithm</a> may be invoked automatically by the
-<a>user agent</a>. When blocked by this policy, a console warning is recorded.
-The <a>default allowlist</a> for this feature is `self`.
+The <a>policy-controlled feature</a> named `"automatic-picture-in-picture"`
+controls whether the <a>request Picture-in-Picture algorithm</a> may be invoked
+automatically by the <a>user agent</a>. When blocked by this policy, a console
+warning is recorded. The <a>default allowlist</a> for this feature is `self`.
 
 # Acknowledgments # {#acknowledgments}
 

--- a/index.bs
+++ b/index.bs
@@ -42,7 +42,6 @@ spec:dom; type:dfn; for:NamedNodeMap; text:element
 spec:dom; type:dfn; text:origin
 spec:dom; type:interface; text:Document
 spec:html; type:attribute; for:HTMLMediaElement; text:readyState
-spec:html; type:dfn; text:allowed to use
 spec:html; type:dfn; for:/; text:browsing context
 spec:infra; type:dfn; text:user agent
 spec:infra; type:dfn; for:list; text:item
@@ -193,30 +192,35 @@ the user agent MUST run the following steps:
 
 1. If <a>Picture-in-Picture support</a> is `false`, throw a
     {{NotSupportedError}} and abort these steps.
-2. If the document is not <a>allowed to use</a> the <a>policy-controlled feature</a>
+2. If the document is not [=/allowed to use=] the <a>policy-controlled feature</a>
     named `"picture-in-picture"`, throw a {{SecurityError}} and abort these
     steps.
-3. If |video|'s {{readyState}} attribute is {{HAVE_NOTHING}}, throw a
+3. If the document is not [=/allowed to use=] the <a>policy-controlled feature</a>
+    named `"automatic-picture-in-picture"` and the
+    {{MediaSessionEnterPictureInPictureReason}} enum is
+    {{MediaSessionEnterPictureInPictureReason/"contentoccluded"}}, throw a
+    {{SecurityError}} and abort these steps.
+4. If |video|'s {{readyState}} attribute is {{HAVE_NOTHING}}, throw a
     {{InvalidStateError}} and abort these steps.
-4. If |video| has no video track, throw a {{InvalidStateError}} and abort
+5. If |video| has no video track, throw a {{InvalidStateError}} and abort
     these steps.
-5. If |video|'s {{HTMLVideoElement/disablePictureInPicture}} is true,
+6. If |video|'s {{HTMLVideoElement/disablePictureInPicture}} is true,
     the user agent MAY throw an {{InvalidStateError}} and abort these steps.
-6. If {{pictureInPictureElement}} is `null` and the <a>relevant global object</a>
+7. If {{pictureInPictureElement}} is `null` and the <a>relevant global object</a>
     of <a>this</a> does not have <a>transient activation</a>, throw a
     {{NotAllowedError}} and abort these steps.
-7. If |video| is {{pictureInPictureElement}}, abort these steps.
-8. Set {{pictureInPictureElement}} to |video|.
-9. Let <dfn>Picture-in-Picture window</dfn> be a new instance of
+8. If |video| is {{pictureInPictureElement}}, abort these steps.
+9. Set {{pictureInPictureElement}} to |video|.
+10. Let <dfn>Picture-in-Picture window</dfn> be a new instance of
     {{PictureInPictureWindow}} associated with {{pictureInPictureElement}}.
-10. Append <a>relevant settings object</a>'s <a>origin</a> to
+11. Append <a>relevant settings object</a>'s <a>origin</a> to
     <a>initiators of active Picture-in-Picture sessions</a>.
-11. <a>Queue a task</a> to <a>fire an event</a> named
+12. <a>Queue a task</a> to <a>fire an event</a> named
     {{enterpictureinpicture}} using {{PictureInPictureEvent}} at the
     |video| with its {{bubbles}} attribute initialized to `true` and its
     {{PictureInPictureEvent/pictureInPictureWindow}} attribute initialized to
     <a>Picture-in-Picture window</a>.
-12. If {{pictureInPictureElement}} is <a>fullscreenElement</a>, it is
+13. If {{pictureInPictureElement}} is <a>fullscreenElement</a>, it is
     RECOMMENDED to <a>exit fullscreen</a>.
 
 It is RECOMMENDED that video frames are not rendered in the page and in the
@@ -374,7 +378,7 @@ partial interface Document {
 
 The {{pictureInPictureEnabled}} attribute's getter must return `true` if
 <a>Picture-in-Picture support</a> is `true` and <a>this</a> is
-<a>allowed to use</a> the feature indicated by attribute name
+[=/allowed to use=] the feature indicated by attribute name
 `picture-in-picture`, and `false` otherwise.
 
 <dfn>Picture-in-Picture support</dfn> is `false` if there's a user preference
@@ -493,26 +497,29 @@ whether picture-in-picture is allowed:
 <dl dfn-type=value>
   <dt>"<dfn permission export>picture-in-picture</dfn>".
   <dd>
-    Controls whether the [=document=] [=allowed to use|is allowed=] to use
+    Controls whether the [=document=] [=/allowed to use|is allowed=] to use
     Picture-in-Picture. The <a>default allowlist</a> for this feature is `*`.
 
   <dt>"<dfn permission export>automatic-picture-in-picture</dfn>".
   <dd>
-    Controls whether the user agent SHOULD automatically trigger
-    Picture-in-Picture. The <a>default allowlist</a> for this feature is
-    `self`.
+    Controls whether the [=document=] [=/allowed to use|is allowed=] to use
+    Picture-in-Picture when the {{MediaSessionEnterPictureInPictureReason}}
+    enum is {{MediaSessionEnterPictureInPictureReason/"contentoccluded"}}. The
+    <a>default allowlist</a> for this feature is `self`.
 </dl>
 
 Access to the Picture-in-Picture API is gated behind the
 <a>policy-controlled feature</a> {{picture-in-picture}}, which has a
 <a>default allowlist</a> of `*`.
 
-When the document is not [=allowed to use=] the
+When the document is not [=/allowed to use=] the
 <a>policy-controlled feature</a> named {{automatic-picture-in-picture}}, the
 user agent SHOULD not trigger a [[MediaSession]]
 {{MediaSessionAction/"enterpictureinpicture"}} action with the
-{{MediaSessionEnterPictureInPictureReason/"contentoccluded"}} reason. The
-<a>default allowlist</a> for this feature is `self`.
+{{MediaSessionEnterPictureInPictureReason/"contentoccluded"}} reason. If such
+action is triggered, the <a>request Picture-in-Picture algorithm</a>. will
+throw a {{SecurityError}}. The <a>default allowlist</a> for this feature is
+`self`.
 
 Note: User agents should surface a console warning whenever
 `"picture-in-picture"` is blocked by the {{automatic-picture-in-picture}}

--- a/index.bs
+++ b/index.bs
@@ -527,6 +527,6 @@ permissions policy.
 
 # Acknowledgments # {#acknowledgments}
 
-Thanks to Jennifer Apacible, Zouhir Chahoud, Marcos Cáceres, Philip Jägenstedt,
-Jeremy Jones, Chris Needham, Jer Noble, Justin Uberti, Yoav Weiss, Eckhart
-Wörner and Benjamin Keen for their contributions to this document.
+Thanks to Jennifer Apacible, Marcos Cáceres, Zouhir Chahoud, Philip Jägenstedt,
+Jeremy Jones, Benjamin Keen, Chris Needham, Jer Noble, Justin Uberti, Yoav Weiss,
+and Eckhart Wörner for their contributions to this document.

--- a/index.bs
+++ b/index.bs
@@ -34,6 +34,10 @@ spec: Remote-Playback; urlPrefix: https://w3c.github.io/remote-playback/#dfn-
     type: dfn
         text: local playback device
         text: local playback state
+spec: MediaSession; urlPrefix: https://w3c.github.io/mediasession
+    type: dfn; text: enterpictureinpicture; url: #dom-mediasessionaction-enterpictureinpicture
+    type: dfn; text: contentoccluded; url: #dom-mediasessionenterpictureinpicturereason-contentoccluded
+    type: dfn; text: media session action; url: #media-session-action
 </pre>
 
 <pre class="link-defaults">
@@ -193,8 +197,8 @@ the user agent MUST run the following steps:
 1. If <a>Picture-in-Picture support</a> is `false`, throw a
     {{NotSupportedError}} and abort these steps.
 2. If the document is not <a>allowed to use</a> the <a>policy-controlled feature</a>
-    named `"picture-in-picture"`, throw a {{SecurityError}} and abort these
-    steps.
+    named {{picture-in-picture}} or {{automatic-picture-in-picture}}, throw a
+    {{SecurityError}} and abort these steps.
 3. If |video|'s {{readyState}} attribute is {{HAVE_NOTHING}}, throw a
     {{InvalidStateError}} and abort these steps.
 4. If |video| has no video track, throw a {{InvalidStateError}} and abort
@@ -302,6 +306,9 @@ Picture-in-Picture.
 
 The API will have to be used with the [[MediaSession]] API for customizing the
 available controls on the Picture-in-Picture window.
+
+The user agent SHOULD not override the <a>media session action</a>
+<a>enterpictureinpicture</a> action handler,  if one is provided by the site.
 
 ## Interaction with Page Visibility ## {#page-visibility}
 
@@ -484,18 +491,23 @@ regardless of the <a>browsing context</a>.
 This specification defines two <a>policy-controlled features</a> that control
 whether picture-in-picture is allowed:
 
-* `"picture-in-picture"`.
-* `"automatic-picture-in-picture"`.
+<dl dfn-type=value>
+  <dt>"<dfn permission export>picture-in-picture</dfn>".
+  <dt>"<dfn permission export>automatic-picture-in-picture</dfn>".
+</dl>
 
-The <a>policy-controlled feature</a> named `"picture-in-picture"` controls
-whether the <a>request Picture-in-Picture algorithm</a> may return a
-{{SecurityError}} and whether {{pictureInPictureEnabled}} is `true` or `false`.
-The <a>default allowlist</a> for this feature is `*`.
+Access to the Picture-in-Picture API is gated behind the
+<a>policy-controlled feature</a> {{picture-in-picture}}, which has a
+<a>default allowlist</a> of `*`.
 
-The <a>policy-controlled feature</a> named `"automatic-picture-in-picture"`
-controls whether the <a>request Picture-in-Picture algorithm</a> may be invoked
-automatically by the <a>user agent</a>. When blocked by this policy, a console
-warning is recorded. The <a>default allowlist</a> for this feature is `self`.
+When the {{automatic-picture-in-picture}} <a>policy-controlled feature</a>
+policy is set, the user agent SHOULD not trigger a [[MediaSession]]
+<a>enterpictureinpicture</a> action with the <a>contentoccluded</a> reason. The
+<a>default allowlist</a> for this feature is `self`.
+
+Note: User agents should surface a console warning whenever
+`"picture-in-picture"` is blocked by the {{automatic-picture-in-picture}}
+permissions policy.
 
 # Acknowledgments # {#acknowledgments}
 

--- a/index.bs
+++ b/index.bs
@@ -34,6 +34,9 @@ spec: Remote-Playback; urlPrefix: https://w3c.github.io/remote-playback/#dfn-
     type: dfn
         text: local playback device
         text: local playback state
+spec: MediaSession; urlPrefix: https://w3c.github.io/mediasession/
+    type: enum; text: MediaSessionEnterPictureInPictureReason; url: #enumdef-mediasessionenterpictureinpicturereason
+    type: enum-value; for: MediaSessionEnterPictureInPictureReason; text: "contentoccluded"; url: #dom-mediasessionenterpictureinpicturereason-contentoccluded
 </pre>
 
 <pre class="link-defaults">
@@ -192,35 +195,36 @@ the user agent MUST run the following steps:
 
 1. If <a>Picture-in-Picture support</a> is `false`, throw a
     {{NotSupportedError}} and abort these steps.
-2. If the document is not [=/allowed to use=] the <a>policy-controlled feature</a>
+1. Let |document| be [=this=]'s [=/relevant global object=]'s [=/associated Document=].
+1. If the |document| is not [=/allowed to use=] the [=policy-controlled feature=]
     named `"picture-in-picture"`, throw a {{SecurityError}} and abort these
     steps.
-3. If the document is not [=/allowed to use=] the <a>policy-controlled feature</a>
+1. If the |document| is not [=/allowed to use=] the <a>policy-controlled feature</a>
     named `"automatic-picture-in-picture"` and the
-    {{MediaSessionEnterPictureInPictureReason}} enum is
+    {{MediaSessionEnterPictureInPictureReason}} enum, defined in [[MediaSession]], is
     {{MediaSessionEnterPictureInPictureReason/"contentoccluded"}}, throw a
     {{SecurityError}} and abort these steps.
-4. If |video|'s {{readyState}} attribute is {{HAVE_NOTHING}}, throw a
+1. If |video|'s {{readyState}} attribute is {{HAVE_NOTHING}}, throw a
     {{InvalidStateError}} and abort these steps.
-5. If |video| has no video track, throw a {{InvalidStateError}} and abort
-    these steps.
-6. If |video|'s {{HTMLVideoElement/disablePictureInPicture}} is true,
-    the user agent MAY throw an {{InvalidStateError}} and abort these steps.
-7. If {{pictureInPictureElement}} is `null` and the <a>relevant global object</a>
+1. If |video| has no video track, throw a {{InvalidStateError}} and abort these
+    steps.
+1. If |video|'s {{HTMLVideoElement/disablePictureInPicture}} is true, the user
+    agent MAY throw an {{InvalidStateError}} and abort these steps.
+1. If {{pictureInPictureElement}} is `null` and the <a>relevant global object</a>
     of <a>this</a> does not have <a>transient activation</a>, throw a
     {{NotAllowedError}} and abort these steps.
-8. If |video| is {{pictureInPictureElement}}, abort these steps.
-9. Set {{pictureInPictureElement}} to |video|.
-10. Let <dfn>Picture-in-Picture window</dfn> be a new instance of
+1. If |video| is {{pictureInPictureElement}}, abort these steps.
+1. Set {{pictureInPictureElement}} to |video|.
+1. Let <dfn>Picture-in-Picture window</dfn> be a new instance of
     {{PictureInPictureWindow}} associated with {{pictureInPictureElement}}.
-11. Append <a>relevant settings object</a>'s <a>origin</a> to
+1. Append <a>relevant settings object</a>'s <a>origin</a> to
     <a>initiators of active Picture-in-Picture sessions</a>.
-12. <a>Queue a task</a> to <a>fire an event</a> named
-    {{enterpictureinpicture}} using {{PictureInPictureEvent}} at the
-    |video| with its {{bubbles}} attribute initialized to `true` and its
+1. <a>Queue a task</a> to <a>fire an event</a> named {{enterpictureinpicture}}
+    using {{PictureInPictureEvent}} at the |video| with its {{bubbles}}
+    attribute initialized to `true` and its
     {{PictureInPictureEvent/pictureInPictureWindow}} attribute initialized to
     <a>Picture-in-Picture window</a>.
-13. If {{pictureInPictureElement}} is <a>fullscreenElement</a>, it is
+1. If {{pictureInPictureElement}} is <a>fullscreenElement</a>, it is
     RECOMMENDED to <a>exit fullscreen</a>.
 
 It is RECOMMENDED that video frames are not rendered in the page and in the
@@ -308,7 +312,7 @@ Picture-in-Picture.
 The API will have to be used with the [[MediaSession]] API for customizing the
 available controls on the Picture-in-Picture window.
 
-The user agent SHOULD not override the media session action
+The user agent SHOULD NOT override the media session action
 {{MediaSessionAction/"enterpictureinpicture"}} action handler, if one is
 provided by the site. This gives the site control over the Picture-in-Picture
 user experience, when a Picture-in-Picture window is requested.
@@ -504,17 +508,14 @@ whether picture-in-picture is allowed:
   <dd>
     Controls whether the [=document=] [=/allowed to use|is allowed=] to use
     Picture-in-Picture when the {{MediaSessionEnterPictureInPictureReason}}
-    enum is {{MediaSessionEnterPictureInPictureReason/"contentoccluded"}}. The
+    enum, defined in [[MediaSession]], is
+    {{MediaSessionEnterPictureInPictureReason/"contentoccluded"}}. The
     <a>default allowlist</a> for this feature is `self`.
 </dl>
 
-Access to the Picture-in-Picture API is gated behind the
-<a>policy-controlled feature</a> {{picture-in-picture}}, which has a
-<a>default allowlist</a> of `*`.
-
 When the document is not [=/allowed to use=] the
 <a>policy-controlled feature</a> named {{automatic-picture-in-picture}}, the
-user agent SHOULD not trigger a [[MediaSession]]
+user agent SHOULD NOT trigger a [[MediaSession]]
 {{MediaSessionAction/"enterpictureinpicture"}} action with the
 {{MediaSessionEnterPictureInPictureReason/"contentoccluded"}} reason. If such
 action is triggered, the <a>request Picture-in-Picture algorithm</a>. will

--- a/index.bs
+++ b/index.bs
@@ -193,6 +193,15 @@ An origin is said to have an active Picture-in-Picture session if any
 of the origins in <a>initiators of active Picture-in-Picture sessions</a>
 are <a>same origin-domain</a> with origin.
 
+An <dfn export>automatic Picture-in-Picture request</dfn> is a request to enter
+Picture-in-Picture initiated by the user agent due to content occlusion. This
+includes the user agent triggering the
+{{MediaSessionAction/"enterpictureinpicture"}} action with the
+{{MediaSessionEnterPictureInPictureReason/"contentoccluded"}} reason if a
+{{MediaSessionActionHandler}} is registered for this action; otherwise, the
+user agent may execute the [=request Picture-in-Picture=] steps directly for a
+video element selected by the user agent.
+
 ## Picture-in-Picture ## {#pip}
 
 It is RECOMMENDED that video frames are not rendered in the page and in the
@@ -318,24 +327,17 @@ The {{requestPictureInPicture()}} method steps <dfn export>request Picture-in-Pi
 2. Let |doc| be [=this=]'s [=node document=].
 3. If |doc| is not [=allowed to use=] the [=policy-controlled feature=]
     named `"picture-in-picture"`, return [=a promise rejected with=] {{NotAllowedError}} {{DOMException}}.
-4. If the |doc| is not [=/allowed to use=] the [=policy-controlled feature=]
-    named `"automatic-picture-in-picture"` and the
-    {{MediaSessionEnterPictureInPictureReason}} enum, defined in
-    [[MediaSession]], is
-    {{MediaSessionEnterPictureInPictureReason/"contentoccluded"}}, return
-    [=a promise rejected with=] {{NotAllowedError}} {{DOMException}}.
-5. If [=this=]'s {{readyState}} attribute is {{HAVE_NOTHING}}, return [=a promise rejected with=] {{InvalidStateError}} {{DOMException}}.
-6. If [=this=] has no video track, return [=a promise rejected with=] {{InvalidStateError}} {{DOMException}}.
-7. If [=this=]'s {{HTMLVideoElement/disablePictureInPicture}} is true, user agent may return [=a promise rejected with=] {{InvalidStateError}} {{DOMException}}.
-8. If |doc|'s [=Picture-in-Picture element=] is `null`:
-    1. If [=this=]'s [=relevant global object=] does not have a [=transient activation=], then return [=a
-       promise rejected with=] {{NotAllowedError}} {{DOMException}}.
+4. If [=this=]'s {{readyState}} attribute is {{HAVE_NOTHING}}, return [=a promise rejected with=] {{InvalidStateError}} {{DOMException}}.
+5. If [=this=] has no video track, return [=a promise rejected with=] {{InvalidStateError}} {{DOMException}}.
+6. If [=this=]'s {{HTMLVideoElement/disablePictureInPicture}} is true, user agent may return [=a promise rejected with=] {{InvalidStateError}} {{DOMException}}.
+7. If |doc|'s [=Picture-in-Picture element=] is `null` and the user agent is not executing these steps directly as part of an [=automatic Picture-in-Picture request=]:
+    1. If [=this=]'s [=relevant global object=] does not have a [=transient activation=], then return [=a promise rejected with=] {{NotAllowedError}} {{DOMException}}.
     2. [=Consume user activation=] given [=this=]'s [=relevant global object=].
-9. If [=this=] is |doc|'s [=Picture-in-Picture element=]:
+8. If [=this=] is |doc|'s [=Picture-in-Picture element=]:
     1. Return [=a promise resolved with=] the [=Picture-in-Picture window=] associated with |doc|'s [=Picture-in-Picture element=].
-10. Let |global| be [=this=]'s [=relevant global object=].
-11. Let |p| be [=a new promise=] created in [=this=]'s [=relevant realm=].
-12. Return |p|, and [=enqueue the following steps=] to |doc|'s [=picture-in-picture parallel queue=]:
+9. Let |global| be [=this=]'s [=relevant global object=].
+10. Let |p| be [=a new promise=] created in [=this=]'s [=relevant realm=].
+11. Return |p|, and [=enqueue the following steps=] to |doc|'s [=picture-in-picture parallel queue=]:
     1. If [=this=] is |doc|'s [=Picture-in-Picture element=]:
         1. [=Queue a global task=] on the [=media element event task source=] given |global| to
             [=/resolve=] |p| with the [=Picture-in-Picture window=] associated with
@@ -481,6 +483,32 @@ The API is not limited to [[SECURE-CONTEXTS]] because it exposes a feature
 to web applications that user agents usually offer natively on all media
 regardless of the <a>browsing context</a>.
 
+## Permissions Integration ## {#permissions-integration}
+
+This specification defines a <a>powerful feature</a> identified by the
+[=powerful feature/name=] `"automatic-picture-in-picture"`.
+
+The `"automatic-picture-in-picture"` permission controls whether the user agent
+is allowed to initiate [=automatic Picture-in-Picture requests=].
+
+The user agent MUST NOT initiate an [=automatic Picture-in-Picture request=]
+for a {{Document}} unless the {{Document}}'s [=relevant settings object=]'s
+[=permission state=] for the `"automatic-picture-in-picture"` feature is
+{{PermissionState/"granted"}}.
+
+Note: The user agent may enforce additional eligibility criteria before
+initiating a request.
+
+The `"automatic-picture-in-picture"` <a>powerful feature</a> defines a
+[=powerful feature/permission revocation algorithm=]. To invoke the
+<dfn export>automatic Picture-in-Picture permission revocation algorithm</dfn>,
+run these steps:
+
+<ol class="algorithm">
+  <li>Let |document| be the [=current global object=]'s [=associated Document=].</li>
+  <li>If |document| has an active Picture-in-Picture session that was initiated by an [=automatic Picture-in-Picture request=], run the [=exit Picture-in-Picture algorithm=] for |document|.</li>
+</ol>
+
 ## Permissions Policy ## {#permissions-policy}
 
 This specification defines two <a>policy-controlled features</a>:
@@ -495,21 +523,17 @@ This specification defines two <a>policy-controlled features</a>:
 
   <dt>"<dfn permission export>automatic-picture-in-picture</dfn>".
   <dd>
-    Controls whether [=request Picture-in-Picture=] returns a promise
-    rejected with {{NotAllowedError}} {{DOMException}} when the
-    {{MediaSessionEnterPictureInPictureReason}} enum, defined in [[MediaSession]], is
-    {{MediaSessionEnterPictureInPictureReason/"contentoccluded"}}. The
-    <a>default allowlist</a> for this feature is `self`.
+    Controls whether the [=powerful feature=] `"automatic-picture-in-picture"`
+    is permitted in the {{Document}}. The <a>default allowlist</a> for this
+    feature is `self`.
 </dl>
 
-If the [=Document=] is not [=allowed to use=] <a permission>automatic-picture-in-picture</a>,
-the user agent SHOULD NOT trigger the
-{{MediaSessionAction/"enterpictureinpicture"}} action with the
-{{MediaSessionEnterPictureInPictureReason/"contentoccluded"}} reason.
+If the {{Document}} is not [=allowed to use=] <a permission>automatic-picture-in-picture</a>,
+the user agent MUST NOT initiate [=automatic Picture-in-Picture requests=].
 
 Note: User agents should surface a console warning whenever
-entering Picture-in-Picture is blocked by the <a permission>automatic-picture-in-picture</a>
-permissions policy.
+an [=automatic Picture-in-Picture request=] is blocked by the
+<a permission>automatic-picture-in-picture</a> permissions policy.
 
 # Acknowledgments # {#acknowledgments}
 

--- a/index.bs
+++ b/index.bs
@@ -488,26 +488,13 @@ regardless of the <a>browsing context</a>.
 This specification defines a <a>powerful feature</a> identified by the
 [=powerful feature/name=] `"automatic-picture-in-picture"`.
 
-The `"automatic-picture-in-picture"` permission controls access to the
-`"automatic-picture-in-picture"` powerful feature.
+When initiating an [=automatic Picture-in-Picture request=], the user agent
+MUST [=request permission to use=] `"automatic-picture-in-picture"`.
 
-The user agent MUST NOT initiate an [=automatic Picture-in-Picture request=]
-for a {{Document}} if the {{Document}}'s [=relevant settings object=]'s
-[=permission state=] for the `"automatic-picture-in-picture"` feature is
-{{PermissionState/"denied"}}.
+If the result of the permission request is {{PermissionState/"denied"}}, the
+user agent MUST run the [=automatic Picture-in-Picture permission revocation algorithm=].
 
-If the [=permission state=] is {{PermissionState/"prompt"}}:
-1. The user agent MUST prompt the user for permission upon initiating the [=automatic Picture-in-Picture request=].
-2. If the user denies the permission, the user agent MUST run the [=automatic Picture-in-Picture permission revocation algorithm=].
-
-Note: When the [=permission state=] is {{PermissionState/"prompt"}}, user
-agents should display the prompt within the Picture-in-Picture window, blocking
-all other interaction until the user responds.
-
-If the [=permission state=] is {{PermissionState/"granted"}}, the user agent
-may initiate the [=automatic Picture-in-Picture request=] without prompting.
-
-Note: The user agent may enforce additional eligibility criteria before
+The user agent MAY enforce additional eligibility criteria before
 initiating an [=automatic Picture-in-Picture request=].
 
 The `"automatic-picture-in-picture"` <a>powerful feature</a> defines a
@@ -542,7 +529,7 @@ This specification defines two <a>policy-controlled features</a>:
 If the {{Document}} is not [=allowed to use=] <a permission>automatic-picture-in-picture</a>,
 the user agent MUST NOT initiate [=automatic Picture-in-Picture requests=].
 
-Note: User agents should surface a console warning whenever
+Note: User agents are encouraged to surface a web a console warning whenever
 an [=automatic Picture-in-Picture request=] is blocked by the
 <a permission>automatic-picture-in-picture</a> permissions policy.
 

--- a/index.bs
+++ b/index.bs
@@ -31,9 +31,6 @@ spec: Fullscreen; urlPrefix: https://fullscreen.spec.whatwg.org
     type: dfn; text: fullscreen flag; url: #fullscreen-flag
     type: dfn; text: fullscreenElement; url: dom-document-fullscreenelement
     type: dfn; text: exit fullscreen; url: fully-exit-fullscreen
-spec: MediaSession; urlPrefix: https://w3c.github.io/mediasession/
-    type: enum; text: MediaSessionEnterPictureInPictureReason; url: #enumdef-mediasessionenterpictureinpicturereason
-    type: enum-value; for: MediaSessionEnterPictureInPictureReason; text: "contentoccluded"; url: #dom-mediasessionenterpictureinpicturereason-contentoccluded
 </pre>
 
 <pre class="link-defaults">
@@ -505,13 +502,13 @@ This specification defines two <a>policy-controlled features</a>:
     <a>default allowlist</a> for this feature is `self`.
 </dl>
 
-If the [=Document=] is not [=allowed to use=] [=automatic-picture-in-picture=],
+If the [=Document=] is not [=allowed to use=] <a permission>automatic-picture-in-picture</a>,
 the user agent SHOULD NOT trigger the
 {{MediaSessionAction/"enterpictureinpicture"}} action with the
 {{MediaSessionEnterPictureInPictureReason/"contentoccluded"}} reason.
 
 Note: User agents should surface a console warning whenever
-entering Picture-in-Picture is blocked by the [=automatic-picture-in-picture=]
+entering Picture-in-Picture is blocked by the <a permission>automatic-picture-in-picture</a>
 permissions policy.
 
 # Acknowledgments # {#acknowledgments}

--- a/index.bs
+++ b/index.bs
@@ -488,16 +488,27 @@ regardless of the <a>browsing context</a>.
 This specification defines a <a>powerful feature</a> identified by the
 [=powerful feature/name=] `"automatic-picture-in-picture"`.
 
-The `"automatic-picture-in-picture"` permission controls whether the user agent
-is allowed to initiate [=automatic Picture-in-Picture requests=].
+The `"automatic-picture-in-picture"` permission controls access to the
+`"automatic-picture-in-picture"` powerful feature.
 
 The user agent MUST NOT initiate an [=automatic Picture-in-Picture request=]
-for a {{Document}} unless the {{Document}}'s [=relevant settings object=]'s
+for a {{Document}} if the {{Document}}'s [=relevant settings object=]'s
 [=permission state=] for the `"automatic-picture-in-picture"` feature is
-{{PermissionState/"granted"}}.
+{{PermissionState/"denied"}}.
+
+If the [=permission state=] is {{PermissionState/"prompt"}}:
+1. The user agent MUST prompt the user for permission upon initiating the [=automatic Picture-in-Picture request=].
+2. If the user denies the permission, the user agent MUST run the [=automatic Picture-in-Picture permission revocation algorithm=].
+
+Note: When the [=permission state=] is {{PermissionState/"prompt"}}, user
+agents should display the prompt within the Picture-in-Picture window, blocking
+all other interaction until the user responds.
+
+If the [=permission state=] is {{PermissionState/"granted"}}, the user agent
+may initiate the [=automatic Picture-in-Picture request=] without prompting.
 
 Note: The user agent may enforce additional eligibility criteria before
-initiating a request.
+initiating an [=automatic Picture-in-Picture request=].
 
 The `"automatic-picture-in-picture"` <a>powerful feature</a> defines a
 [=powerful feature/permission revocation algorithm=]. To invoke the


### PR DESCRIPTION
This PR modifies the **Permissions Policy** section to include a new policy for automatic picture-in-picture. The policy will allow controlling whether the user agent can automatically enter picture-in-picture.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/bpkeen/picture-in-picture/pull/241.html" title="Last updated on Jul 29, 2026, 12:42 AM UTC (e961626)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/picture-in-picture/241/46651d5...bpkeen:e961626.html" title="Last updated on Jul 29, 2026, 12:42 AM UTC (e961626)">Diff</a>