### PR TITLE
Remove the Interaction with Media Session section

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -287,11 +287,6 @@ the user agent MAY run these steps:
 It is RECOMMENDED to run the <a>exit Picture-in-Picture algorithm</a> when the
 {{pictureInPictureElement}} <a>fullscreen flag</a> is set.
 
-## Interaction with Media Session ## {#media-session}
-
-The API will have to be used with the [[MediaSession]] API for customizing the
-available controls on the Picture-in-Picture window.
-
 ## Interaction with Page Visibility ## {#page-visibility}
 
 When {{pictureInPictureElement}} is set, the Picture-in-Picture window MUST


### PR DESCRIPTION
See #191. There is no behaviour specified in Media Session for customizing controls in Picture in Picture windows, so this section isn't really saying anything.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/picture-in-picture/pull/242.html" title="Last updated on Dec 4, 2025, 10:46 AM UTC (d5572a3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/picture-in-picture/242/13df9af...d5572a3.html" title="Last updated on Dec 4, 2025, 10:46 AM UTC (d5572a3)">Diff</a>