### PR TITLE
Address requestPictureInPicture() algorithm

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -188,7 +188,8 @@ are <a>same origin-domain</a> with origin.
 
 ## Request Picture-in-Picture ## {#request-pip}
 
-See {{requestPictureInPicture()}} for API algorithm steps.
+The <dfn export>request Picture-in-Picture algorithm</dfn> is the set of steps
+run when {{HTMLVideoElement/requestPictureInPicture()}} is invoked.
 
 It is RECOMMENDED that video frames are not rendered in the page and in the
 Picture-in-Picture window at the same time but if they are, they MUST be kept

--- a/index.bs
+++ b/index.bs
@@ -322,8 +322,8 @@ The {{requestPictureInPicture()}} method steps are:
     {{NotAllowedError}} exception and return |p|.
 9. Return promise, and run the remaining steps in parallel:
     1. If <a>this</a> is {{pictureInPictureElement}}:
-        1. Queue a global task on the DOM manipulation task source given global to [=/resolve=] the <a>Picture-in-Picture window</a> associated with
-            {{pictureInPictureElement}}
+        1. Queue a global task on the DOM manipulation task source given global to [=/resolve=] |p| with
+            the <a>Picture-in-Picture window</a> associated with {{pictureInPictureElement}}
         2. return
     2. Let <dfn>Picture-in-Picture window</dfn> be a new instance of
         {{PictureInPictureWindow}} associated with <a>this</a>.

--- a/index.bs
+++ b/index.bs
@@ -313,7 +313,7 @@ The {{requestPictureInPicture()}} method steps are:
 2. Let |global| be <a>this</a>'s <a>relevant global object</a>.
 3. If <a>Picture-in-Picture support</a> is `false`, return [=a promise rejected with=] {{NotSupportedError}} {{DOMException}}.
 4. If [=this=]'s [=node document=] is not [=allowed to use=] the [=policy-controlled feature=]
-    named `"picture-in-picture"`, reject |p| with a {{SecurityError}} exception and 
+    named `"picture-in-picture"`, reject |p| with a {{SecurityError}} {{DOMException}} and 
     return |p|.
 5. If <a>this</a>'s {{readyState}} attribute is {{HAVE_NOTHING}}, reject |p| with an
     {{InvalidStateError}} exception and return |p|.

--- a/index.bs
+++ b/index.bs
@@ -312,7 +312,7 @@ The {{requestPictureInPicture()}} method steps are:
 1. Let |p| be [=a new promise=] created in [=this=]'s [=relevant realm=].
 2. Let |global| be <a>this</a>'s <a>relevant global object</a>.
 3. If <a>Picture-in-Picture support</a> is `false`, return [=a promise rejected with=] {{NotSupportedError}} {{DOMException}}.
-4. If <a>this</a>'s <a>node document</a> is not <a>allowed to use</a> the <a>policy-controlled feature</a>
+4. If [=this=]'s [=node document=] is not [=allowed to use=] the [=policy-controlled feature=]
     named `"picture-in-picture"`, reject |p| with a {{SecurityError}} exception and 
     return |p|.
 5. If <a>this</a>'s {{readyState}} attribute is {{HAVE_NOTHING}}, reject |p| with an

--- a/index.bs
+++ b/index.bs
@@ -306,8 +306,7 @@ The {{requestPictureInPicture()}} method steps are:
 
 1. Let |p| be [=a new promise=] created in [=this=]'s [=relevant realm=].
 2. Let |global| be <a>this</a>'s <a>relevant global object</a>.
-3. If <a>Picture-in-Picture support</a> is `false`, reject |p| with a
-    {{NotSupportedError}} exception and return |p|.
+3. If <a>Picture-in-Picture support</a> is `false`, return [=a promise rejected with=] {{NotSupportedError}} {{DOMException}}.
 4. If <a>this</a>'s <a>node document</a> is not <a>allowed to use</a> the <a>policy-controlled feature</a>
     named `"picture-in-picture"`, reject |p| with a {{SecurityError}} exception and 
     return |p|.

--- a/index.bs
+++ b/index.bs
@@ -169,6 +169,11 @@ to initiate and control this behavior by exposing the following sets of properti
 
 ## Internal Slot Definitions ## {#defines}
 
+A <a>Document</a> has:
+
+1. A <dfn>Picture-in-Picture element</dfn>, which is an element or null,
+    initially null.
+
 A <a>user agent</a> has:
 
 1. An <dfn>initiators of active Picture-in-Picture sessions</dfn>
@@ -203,7 +208,7 @@ It is also RECOMMENDED that the Picture-in-Picture window has a maximum and
 minimum size. For example, it could be restricted to be between a quarter and
 a half of one dimension of the screen.
 
-When a {{DocumentOrShadowRoot}}'s {{pictureInPictureElement}} attribute is set,
+When a {{DocumentOrShadowRoot}}'s <a>Picture-in-Picture element</a> is set,
 the [=Picture-in-Picture window=] MUST be visible, even when the
 {{DocumentOrShadowRoot}}'s [=relevant global object=]'s [=associated Document=]'s
 [=Document/visibility state=] is "hidden".
@@ -330,7 +335,7 @@ The {{requestPictureInPicture()}} method steps are:
 
         Note: A user agent may abort when it deems necessary, e.g. due to an error. When doing so it must queue a global task on the <a>media element event task source</a> given |global| and reject the promise with an {{InvalidStateError}}.
     3. Queue a global task on the <a>media element event task source</a> given |global|, to perform the following steps:
-        1. Set {{pictureInPictureElement}} to <a>this</a>.
+        1. Set <a>this</a>'s <a>node document</a>'s <a>Picture-in-Picture element</a> to <a>this</a>.
         2. [=list/Append=] <a>relevant settings object</a>'s <a>origin</a> to
             <a>initiators of active Picture-in-Picture sessions</a>.
         3. If {{pictureInPictureElement}} is <a>fullscreenElement</a>, it is
@@ -382,8 +387,8 @@ The {{pictureInPictureElement}} attribute's getter must run these steps:
 
 1. If <a>this</a> is a <a for=/>shadow root</a> and its <a for=DocumentFragment>host</a>
     is not <a>connected</a>, return `null` and abort these steps.
-2. Let |candidate| be the result of <a>retargeting</a> Picture-in-Picture
-    element against <a>this</a>.
+2. Let |candidate| be the result of <a>retargeting</a> <a>Picture-in-Picture element</a>
+    against <a>this</a>.
 3. If |candidate| and <a>this</a> are in the same <a>tree</a>,
     return |candidate| and abort these steps.
 4. Return `null`.

--- a/index.bs
+++ b/index.bs
@@ -322,12 +322,12 @@ The {{requestPictureInPicture()}} method steps are:
     {{NotAllowedError}} exception and return |p|.
 9. Return promise, and run the remaining steps in parallel:
     1. If <a>this</a> is {{pictureInPictureElement}}:
-        1. Queue a global task on the DOM manipulation task source given global to [=/resolve=] |p| with
+        1. Queue a global task on the <a>media element event task source</a> given |global| to [=/resolve=] |p| with
             the <a>Picture-in-Picture window</a> associated with {{pictureInPictureElement}}
         2. abort these steps
     2. Let <dfn>Picture-in-Picture window</dfn> be a new instance of
         {{PictureInPictureWindow}} associated with <a>this</a>.
-    3. Queue a global task on the DOM manipulation task source given **global**, to perform the following steps:
+    3. Queue a global task on the <a>media element event task source</a> given |global|, to perform the following steps:
         1. Set {{pictureInPictureElement}} to <a>this</a>.
         2. Append <a>relevant settings object</a>'s <a>origin</a> to
             <a>initiators of active Picture-in-Picture sessions</a>.

--- a/index.bs
+++ b/index.bs
@@ -316,9 +316,10 @@ The {{requestPictureInPicture()}} method steps are:
     and return |p|.
 7. If <a>this</a>'s {{HTMLVideoElement/disablePictureInPicture}} is true,
     the user agent MAY reject |p| with an {{InvalidStateError}} exception and return |p|.
-8. If {{pictureInPictureElement}} is `null` and the <a>relevant global object</a>
-    of <a>this</a> does not have <a>transient activation</a>, reject |p| with a
-    {{NotAllowedError}} exception and return |p|.
+8. If {{pictureInPictureElement}} is `null`:
+    1. If <a>this</a>'s <a>relevant global object</a> does not have a <a>transient activation</a>
+        reject |p| with a {{NotAllowedError}} exception and return |p|.
+    2. [=Consume user activation=] given <a>this</a>'s <a>relevant global object</a>.
 9. Return |promise|, and run the remaining steps |in parallel|:
     1. If <a>this</a> is {{pictureInPictureElement}}:
         1. Queue a global task on the <a>media element event task source</a> given |global| to [=/resolve=] |p| with

--- a/index.bs
+++ b/index.bs
@@ -26,6 +26,11 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/multipage/
     type: dfn
         urlPrefix: interaction.html
             text: system visibility state
+    type: dfn
+        urlPrefix: infrastructure.html
+            text: parallel queue
+            text: starting a new parallel queue
+            text: enqueue the following steps
 spec: Fullscreen; urlPrefix: https://fullscreen.spec.whatwg.org
     type: dfn; text: fullscreen flag; url: #fullscreen-flag
     type: dfn; text: fullscreenElement; url: dom-document-fullscreenelement
@@ -171,16 +176,16 @@ to initiate and control this behavior by exposing the following sets of properti
 
 A <a>Document</a> has:
 
-1. A <dfn>Picture-in-Picture element</dfn>, which is an {{Element}} or null,
-    initially null.
+1. A <dfn>Picture-in-Picture element</dfn>, which is an {{Element}} or null, initially null.
 
 A <a>user agent</a> has:
 
 1. An <dfn>initiators of active Picture-in-Picture sessions</dfn>
     list of zero or more <a>origins</a>, which is initially empty.
 
-Note: In case a <a>user agent</a> supports multiple Picture-in-Picture
-  windows, the list allows duplicates.
+    Note: In case a <a>user agent</a> supports multiple Picture-in-Picture windows, the list allows duplicates.
+2. A <dfn>picture-in-picture parallel queue</dfn> (a [=parallel queue=]), initially the result of
+    [=starting a new parallel queue=].
 
 An origin is said to have an active Picture-in-Picture session if any
 of the origins in <a>initiators of active Picture-in-Picture sessions</a>
@@ -323,7 +328,7 @@ The {{requestPictureInPicture()}} method steps are:
     2. [=Consume user activation=] given [=this=]'s [=relevant global object=].
 7. Let |global| be [=this=]'s [=relevant global object=].
 8. Let |p| be [=a new promise=] created in [=this=]'s [=relevant realm=].
-9. Return |p|, and run the remaining steps |in parallel|:
+9. Return |p|, and [=enqueue the following steps=] to the [=user agent=]'s [=picture-in-picture parallel queue=]:
     1. If [=this=] is {{pictureInPictureElement}}:
         1. Queue a global task on the [=media element event task source=] given |global| to
             [=/resolve=] |p| with the [=Picture-in-Picture window=] associated with

--- a/index.bs
+++ b/index.bs
@@ -318,7 +318,7 @@ The {{requestPictureInPicture()}} method steps are:
 5. If [=this=]'s {{HTMLVideoElement/disablePictureInPicture}} is true, the user agent MAY return [=a
    promise rejected with=] {{InvalidStateError}} {{DOMException}}.
 6. If {{pictureInPictureElement}} is `null`:
-    1. If [=this=]'s [=relevant global object=] does not have a [=transient activation=] return [=a
+    1. If [=this=]'s [=relevant global object=] does not have a [=transient activation=], then return [=a
        promise rejected with=] {{NotAllowedError}} {{DOMException}}
     2. [=Consume user activation=] given [=this=]'s [=relevant global object=].
 7. Let |global| be [=this=]'s [=relevant global object=].

--- a/index.bs
+++ b/index.bs
@@ -304,7 +304,7 @@ partial interface HTMLVideoElement {
 
 The {{requestPictureInPicture()}} method steps are:
 
-1. Let |p| be a new promise created in <a>this</a>'s relevant realm.
+1. Let |p| be [=a new promise=] created in [=this=]'s [=relevant realm=].
 2. Let |global| be <a>this</a>'s <a>relevant global object</a>.
 3. If <a>Picture-in-Picture support</a> is `false`, reject |p| with a
     {{NotSupportedError}} exception and return |p|.

--- a/index.bs
+++ b/index.bs
@@ -326,9 +326,11 @@ The {{requestPictureInPicture()}} method steps are:
     1. If [=this=]'s [=relevant global object=] does not have a [=transient activation=], then return [=a
        promise rejected with=] {{NotAllowedError}} {{DOMException}}
     2. [=Consume user activation=] given [=this=]'s [=relevant global object=].
-7. Let |global| be [=this=]'s [=relevant global object=].
-8. Let |p| be [=a new promise=] created in [=this=]'s [=relevant realm=].
-9. Return |p|, and [=enqueue the following steps=] to the [=user agent=]'s [=picture-in-picture parallel queue=]:
+7. If [=this=] is {{pictureInPictureElement}}:
+    1. Return [=a promise resolved with=] with the [=Picture-in-Picture window=] associated with {{pictureInPictureElement}}
+8. Let |global| be [=this=]'s [=relevant global object=].
+9. Let |p| be [=a new promise=] created in [=this=]'s [=relevant realm=].
+10. Return |p|, and [=enqueue the following steps=] to the [=user agent=]'s [=picture-in-picture parallel queue=]:
     1. If [=this=] is {{pictureInPictureElement}}:
         1. Queue a global task on the [=media element event task source=] given |global| to
             [=/resolve=] |p| with the [=Picture-in-Picture window=] associated with

--- a/index.bs
+++ b/index.bs
@@ -324,7 +324,7 @@ The {{requestPictureInPicture()}} method steps are:
     1. If <a>this</a> is {{pictureInPictureElement}}:
         1. Queue a global task on the DOM manipulation task source given global to [=/resolve=] |p| with
             the <a>Picture-in-Picture window</a> associated with {{pictureInPictureElement}}
-        2. return
+        2. abort these steps
     2. Let <dfn>Picture-in-Picture window</dfn> be a new instance of
         {{PictureInPictureWindow}} associated with <a>this</a>.
     3. Queue a global task on the DOM manipulation task source given **global**, to perform the following steps:

--- a/index.bs
+++ b/index.bs
@@ -351,8 +351,8 @@ The {{requestPictureInPicture()}} method steps are:
             Picture-in-Picture sessions=].
         3. If {{pictureInPictureElement}} is [=fullscreenElement=], it is RECOMMENDED to [=exit
            fullscreen=].
-        4. [=Fire an event=] named {{enterpictureinpicture}} using {{PictureInPictureEvent}} at
-            the |video| with its {{bubbles}} attribute initialized to `true` and its
+        4. [=Fire an event=] named {{enterpictureinpicture}} using {{PictureInPictureEvent}} at the
+            [=this=] with its {{bubbles}} attribute initialized to `true` and its
             {{PictureInPictureEvent/pictureInPictureWindow}} attribute initialized to
             [=Picture-in-Picture window=].
         5. [=/Resolve=] |p| with the [=Picture-in-Picture window=] associated with

--- a/index.bs
+++ b/index.bs
@@ -330,7 +330,7 @@ The {{requestPictureInPicture()}} method steps are:
         Note: A user agent may abort when it deems necessary, e.g. due to an error. When doing so it must queue a global task on the <a>media element event task source</a> given |global| and reject the promise with an {{InvalidStateError}}.
     3. Queue a global task on the <a>media element event task source</a> given |global|, to perform the following steps:
         1. Set {{pictureInPictureElement}} to <a>this</a>.
-        2. Append <a>relevant settings object</a>'s <a>origin</a> to
+        2. [=list/Append=] <a>relevant settings object</a>'s <a>origin</a> to
             <a>initiators of active Picture-in-Picture sessions</a>.
         3. If {{pictureInPictureElement}} is <a>fullscreenElement</a>, it is
             RECOMMENDED to <a>exit fullscreen</a>.

--- a/index.bs
+++ b/index.bs
@@ -327,6 +327,8 @@ The {{requestPictureInPicture()}} method steps are:
         2. abort these steps
     2. Let <dfn>Picture-in-Picture window</dfn> be a new instance of
         {{PictureInPictureWindow}} associated with <a>this</a>.
+
+        Note: A user agent may abort when it deems necessary, e.g. due to an error. When doing so it must queue a global task on the <a>media element event task source</a> given |global| and reject the promise with an {{InvalidStateError}}.
     3. Queue a global task on the <a>media element event task source</a> given |global|, to perform the following steps:
         1. Set {{pictureInPictureElement}} to <a>this</a>.
         2. Append <a>relevant settings object</a>'s <a>origin</a> to

--- a/index.bs
+++ b/index.bs
@@ -309,42 +309,45 @@ partial interface HTMLVideoElement {
 
 The {{requestPictureInPicture()}} method steps are:
 
-1. Let |p| be [=a new promise=] created in [=this=]'s [=relevant realm=].
-2. Let |global| be <a>this</a>'s <a>relevant global object</a>.
-3. If <a>Picture-in-Picture support</a> is `false`, return [=a promise rejected with=] {{NotSupportedError}} {{DOMException}}.
-4. If [=this=]'s [=node document=] is not [=allowed to use=] the [=policy-controlled feature=]
-    named `"picture-in-picture"`, reject |p| with a {{SecurityError}} {{DOMException}} and 
-    return |p|.
-5. If <a>this</a>'s {{readyState}} attribute is {{HAVE_NOTHING}}, reject |p| with an
-    {{InvalidStateError}} exception and return |p|.
-6. If <a>this</a> has no video track, reject |p| with an {{InvalidStateError}} exception 
-    and return |p|.
-7. If <a>this</a>'s {{HTMLVideoElement/disablePictureInPicture}} is true,
-    the user agent MAY reject |p| with an {{InvalidStateError}} exception and return |p|.
-8. If {{pictureInPictureElement}} is `null`:
-    1. If <a>this</a>'s <a>relevant global object</a> does not have a <a>transient activation</a>
-        reject |p| with a {{NotAllowedError}} exception and return |p|.
-    2. [=Consume user activation=] given <a>this</a>'s <a>relevant global object</a>.
-9. Return |promise|, and run the remaining steps |in parallel|:
-    1. If <a>this</a> is {{pictureInPictureElement}}:
-        1. Queue a global task on the <a>media element event task source</a> given |global| to [=/resolve=] |p| with
-            the <a>Picture-in-Picture window</a> associated with {{pictureInPictureElement}}
+1. If [=Picture-in-Picture support=] is `false`, return [=a promise rejected with=] {{NotSupportedError}} {{DOMException}}.
+2. If [=this=]'s [=node document=] is not [=allowed to use=] the [=policy-controlled feature=]
+    named `"picture-in-picture"`, return [=a promise rejected with=] {{SecurityError}} {{DOMException}}.
+3. If [=this=]'s {{readyState}} attribute is {{HAVE_NOTHING}}, return [=a promise rejected with=] with {{InvalidStateError}} {{DOMException}}
+4. If [=this=] has no video track, return [=a promise rejected with=] {{InvalidStateError}} {{DOMException}}
+5. If [=this=]'s {{HTMLVideoElement/disablePictureInPicture}} is true, the user agent MAY return [=a
+   promise rejected with=] {{InvalidStateError}} {{DOMException}}.
+6. If {{pictureInPictureElement}} is `null`:
+    1. If [=this=]'s [=relevant global object=] does not have a [=transient activation=] return [=a
+       promise rejected with=] {{NotAllowedError}} {{DOMException}}
+    2. [=Consume user activation=] given [=this=]'s [=relevant global object=].
+7. Let |global| be [=this=]'s [=relevant global object=].
+8. Let |p| be [=a new promise=] created in [=this=]'s [=relevant realm=].
+9. Return |p|, and run the remaining steps |in parallel|:
+    1. If [=this=] is {{pictureInPictureElement}}:
+        1. Queue a global task on the [=media element event task source=] given |global| to
+            [=/resolve=] |p| with the [=Picture-in-Picture window=] associated with
+            {{pictureInPictureElement}}
         2. abort these steps
-    2. Let <dfn>Picture-in-Picture window</dfn> be a new instance of
-        {{PictureInPictureWindow}} associated with <a>this</a>.
+    2. Let <dfn>Picture-in-Picture window</dfn> be a new instance of {{PictureInPictureWindow}}
+        associated with [=this=].
 
-        Note: A user agent may abort when it deems necessary, e.g. due to an error. When doing so it must queue a global task on the <a>media element event task source</a> given |global| and reject the promise with an {{InvalidStateError}}.
-    3. Queue a global task on the <a>media element event task source</a> given |global|, to perform the following steps:
-        1. Set <a>this</a>'s <a>node document</a>'s <a>Picture-in-Picture element</a> to <a>this</a>.
-        2. [=list/Append=] <a>relevant settings object</a>'s <a>origin</a> to
-            <a>initiators of active Picture-in-Picture sessions</a>.
-        3. If {{pictureInPictureElement}} is <a>fullscreenElement</a>, it is
-            RECOMMENDED to <a>exit fullscreen</a>.
-        4. <a>Fire an event</a> named {{enterpictureinpicture}} using {{PictureInPictureEvent}} at the
-            |video| with its {{bubbles}} attribute initialized to `true` and its
+        Note: A user agent may abort when it deems necessary, e.g. due to an error.
+    3. In case where user agent aborted:
+        1. [=Queue a global task=] on the [=media element event task source=] given |global| to
+            [=/reject=] |p| with {{InvalidStateError}} {{DOMException}}
+        2. abort these steps
+    4. [=Queue a global task=] on the [=media element event task source=] given |global|, to perform
+        the following steps:
+        1. Set [=this=]'s [=node document=]'s [=Picture-in-Picture element=] to [=this=].
+        2. [=list/Append=] [=relevant settings object=]'s [=origin=] to [=initiators of active
+            Picture-in-Picture sessions=].
+        3. If {{pictureInPictureElement}} is [=fullscreenElement=], it is RECOMMENDED to [=exit
+           fullscreen=].
+        4. [=Fire an event=] named {{enterpictureinpicture}} using {{PictureInPictureEvent}} at
+            the |video| with its {{bubbles}} attribute initialized to `true` and its
             {{PictureInPictureEvent/pictureInPictureWindow}} attribute initialized to
-            <a>Picture-in-Picture window</a>.
-        5. [=/Resolve=] |p| with the <a>Picture-in-Picture window</a> associated with 
+            [=Picture-in-Picture window=].
+        5. [=/Resolve=] |p| with the [=Picture-in-Picture window=] associated with
             {{pictureInPictureElement}}.
 
 

--- a/index.bs
+++ b/index.bs
@@ -183,37 +183,7 @@ are <a>same origin-domain</a> with origin.
 
 ## Request Picture-in-Picture ## {#request-pip}
 
-When the <dfn>request Picture-in-Picture algorithm</dfn> with |video| is invoked,
-the user agent MUST run the following steps:
-
-1. If <a>Picture-in-Picture support</a> is `false`, throw a
-    {{NotSupportedError}} and abort these steps.
-2. If the document is not <a>allowed to use</a> the <a>policy-controlled feature</a>
-    named `"picture-in-picture"`, throw a {{SecurityError}} and abort these
-    steps.
-3. If |video|'s {{readyState}} attribute is {{HAVE_NOTHING}}, throw a
-    {{InvalidStateError}} and abort these steps.
-4. If |video| has no video track, throw a {{InvalidStateError}} and abort
-    these steps.
-5. If |video|'s {{HTMLVideoElement/disablePictureInPicture}} is true,
-    the user agent MAY throw an {{InvalidStateError}} and abort these steps.
-6. If {{pictureInPictureElement}} is `null`:
-    1. If <a>this</a>'s <a>relevant global object</a> does not have 
-        <a>transient activation</a>, throw a {{NotAllowedError}} and abort these steps.
-    2. [=Consume user activation=] given <a>this</a>'s <a>relevant global object</a>.
-7. If |video| is {{pictureInPictureElement}}, abort these steps.
-8. Set {{pictureInPictureElement}} to |video|.
-9. Let <dfn>Picture-in-Picture window</dfn> be a new instance of
-    {{PictureInPictureWindow}} associated with {{pictureInPictureElement}}.
-10. Append <a>relevant settings object</a>'s <a>origin</a> to
-    <a>initiators of active Picture-in-Picture sessions</a>.
-11. <a>Queue a task</a> to <a>fire an event</a> named
-    {{enterpictureinpicture}} using {{PictureInPictureEvent}} at the
-    |video| with its {{bubbles}} attribute initialized to `true` and its
-    {{PictureInPictureEvent/pictureInPictureWindow}} attribute initialized to
-    <a>Picture-in-Picture window</a>.
-12. If {{pictureInPictureElement}} is <a>fullscreenElement</a>, it is
-    RECOMMENDED to <a>exit fullscreen</a>.
+See {{requestPictureInPicture()}} for API algorithm steps.
 
 It is RECOMMENDED that video frames are not rendered in the page and in the
 Picture-in-Picture window at the same time but if they are, they MUST be kept
@@ -332,16 +302,44 @@ partial interface HTMLVideoElement {
 };
 </pre>
 
-The {{requestPictureInPicture()}} method, when invoked, MUST
-return <a>a new promise</a> |promise| and run the following steps <a>in
-parallel</a>:
+The {{requestPictureInPicture()}} method steps are:
 
-1. Let |video| be the video element on which the method was invoked.
-2. Run the <a>request Picture-in-Picture algorithm</a> with |video|.
-3. If the previous step threw an exception, reject |promise| with that
-    exception and abort these steps.
-4. [=/Resolve=] |promise| with the <a>Picture-in-Picture window</a> associated with
-    {{pictureInPictureElement}}.
+1. Let |p| be a new promise created in <a>this</a>'s relevant realm.
+2. Let |global| be <a>this</a>'s <a>relevant global object</a>.
+3. If <a>Picture-in-Picture support</a> is `false`, reject |p| with a
+    {{NotSupportedError}} exception and return |p|.
+4. If <a>this</a>'s <a>node document</a> is not <a>allowed to use</a> the <a>policy-controlled feature</a>
+    named `"picture-in-picture"`, reject |p| with a {{SecurityError}} exception and 
+    return |p|.
+5. If <a>this</a>'s {{readyState}} attribute is {{HAVE_NOTHING}}, reject |p| with an
+    {{InvalidStateError}} exception and return |p|.
+6. If <a>this</a> has no video track, reject |p| with an {{InvalidStateError}} exception 
+    and return |p|.
+7. If <a>this</a>'s {{HTMLVideoElement/disablePictureInPicture}} is true,
+    the user agent MAY reject |p| with an {{InvalidStateError}} exception and return |p|.
+8. If {{pictureInPictureElement}} is `null` and the <a>relevant global object</a>
+    of <a>this</a> does not have <a>transient activation</a>, reject |p| with a
+    {{NotAllowedError}} exception and return |p|.
+9. Return promise, and run the remaining steps in parallel:
+    1. If <a>this</a> is {{pictureInPictureElement}}:
+        1. Queue a global task on the DOM manipulation task source given global to [=/resolve=] the <a>Picture-in-Picture window</a> associated with
+            {{pictureInPictureElement}}
+        2. return
+    2. Let <dfn>Picture-in-Picture window</dfn> be a new instance of
+        {{PictureInPictureWindow}} associated with <a>this</a>.
+    3. Queue a global task on the DOM manipulation task source given **global**, to perform the following steps:
+        1. Set {{pictureInPictureElement}} to <a>this</a>.
+        2. Append <a>relevant settings object</a>'s <a>origin</a> to
+            <a>initiators of active Picture-in-Picture sessions</a>.
+        3. If {{pictureInPictureElement}} is <a>fullscreenElement</a>, it is
+            RECOMMENDED to <a>exit fullscreen</a>.
+        4. <a>Fire an event</a> named {{enterpictureinpicture}} using {{PictureInPictureEvent}} at the
+            |video| with its {{bubbles}} attribute initialized to `true` and its
+            {{PictureInPictureEvent/pictureInPictureWindow}} attribute initialized to
+            <a>Picture-in-Picture window</a>.
+        5. [=/Resolve=] |p| with the <a>Picture-in-Picture window</a> associated with 
+            {{pictureInPictureElement}}.
+
 
 ## Extensions to <code>Document</code> ## {#document-extensions}
 

--- a/index.bs
+++ b/index.bs
@@ -319,7 +319,7 @@ The {{requestPictureInPicture()}} method steps are:
 8. If {{pictureInPictureElement}} is `null` and the <a>relevant global object</a>
     of <a>this</a> does not have <a>transient activation</a>, reject |p| with a
     {{NotAllowedError}} exception and return |p|.
-9. Return promise, and run the remaining steps in parallel:
+9. Return |promise|, and run the remaining steps |in parallel|:
     1. If <a>this</a> is {{pictureInPictureElement}}:
         1. Queue a global task on the <a>media element event task source</a> given |global| to [=/resolve=] |p| with
             the <a>Picture-in-Picture window</a> associated with {{pictureInPictureElement}}

--- a/index.bs
+++ b/index.bs
@@ -171,7 +171,7 @@ to initiate and control this behavior by exposing the following sets of properti
 
 A <a>Document</a> has:
 
-1. A <dfn>Picture-in-Picture element</dfn>, which is an element or null,
+1. A <dfn>Picture-in-Picture element</dfn>, which is an {{Element}} or null,
     initially null.
 
 A <a>user agent</a> has:

--- a/index.bs
+++ b/index.bs
@@ -190,10 +190,10 @@ An origin is said to have an active Picture-in-Picture session if any
 of the origins in <a>initiators of active Picture-in-Picture sessions</a>
 are <a>same origin-domain</a> with origin.
 
-## Request Picture-in-Picture ## {#request-pip}
+## Picture-in-Picture ## {#pip}
 
-The <dfn export>request Picture-in-Picture algorithm</dfn> is the set of steps
-run when {{HTMLVideoElement/requestPictureInPicture()}} is invoked.
+To enter picture-in-picture is to have script invoke
+{{HTMLVideoElement/requestPictureInPicture()}}.
 
 It is RECOMMENDED that video frames are not rendered in the page and in the
 Picture-in-Picture window at the same time but if they are, they MUST be kept

--- a/index.bs
+++ b/index.bs
@@ -316,7 +316,7 @@ The {{requestPictureInPicture()}} method steps <dfn>request Picture-in-Picture</
 
 1. If [=Picture-in-Picture support=] is `false`, return [=a promise rejected with=] {{NotSupportedError}} {{DOMException}}.
 2. If [=this=]'s [=node document=] is not [=allowed to use=] the [=policy-controlled feature=]
-    named `"picture-in-picture"`, return [=a promise rejected with=] {{SecurityError}} {{DOMException}}.
+    named `"picture-in-picture"`, return [=a promise rejected with=] {{NotAllowedError}} {{DOMException}}.
 3. If [=this=]'s {{readyState}} attribute is {{HAVE_NOTHING}}, return [=a promise rejected with=] {{InvalidStateError}} {{DOMException}}
 4. If [=this=] has no video track, return [=a promise rejected with=] {{InvalidStateError}} {{DOMException}}.
 5. If [=this=]'s {{HTMLVideoElement/disablePictureInPicture}} is true, return [=a promise rejected with=] {{InvalidStateError}} {{DOMException}}.

--- a/index.bs
+++ b/index.bs
@@ -39,6 +39,7 @@ spec:dom; type:dfn; text:origin
 spec:dom; type:interface; text:Document
 spec:html; type:attribute; for:HTMLMediaElement; text:readyState
 spec:html; type:dfn; for:/; text:browsing context
+spec:html; type:dfn; text:allowed to use
 spec:infra; type:dfn; text:user agent
 spec:infra; type:dfn; for:list; text:item
 </pre>
@@ -310,24 +311,25 @@ partial interface HTMLVideoElement {
 };
 </pre>
 
-The {{requestPictureInPicture()}} method steps <dfn>request Picture-in-Picture</dfn>:
+The {{requestPictureInPicture()}} method steps <dfn export>request Picture-in-Picture</dfn>:
 
 1. If [=Picture-in-Picture support=] is `false`, return [=a promise rejected with=] {{NotSupportedError}} {{DOMException}}.
-2. If [=this=]'s [=node document=] is not [=allowed to use=] the [=policy-controlled feature=]
+2. Let |doc| be [=this=]'s [=node document=].
+3. If |doc| is not [=allowed to use=] the [=policy-controlled feature=]
     named `"picture-in-picture"`, return [=a promise rejected with=] {{NotAllowedError}} {{DOMException}}.
-3. If [=this=]'s {{readyState}} attribute is {{HAVE_NOTHING}}, return [=a promise rejected with=] {{InvalidStateError}} {{DOMException}}
-4. If [=this=] has no video track, return [=a promise rejected with=] {{InvalidStateError}} {{DOMException}}.
-5. If [=this=]'s {{HTMLVideoElement/disablePictureInPicture}} is true, return [=a promise rejected with=] {{InvalidStateError}} {{DOMException}}.
-6. If {{pictureInPictureElement}} is `null`:
+4. If [=this=]'s {{readyState}} attribute is {{HAVE_NOTHING}}, return [=a promise rejected with=] {{InvalidStateError}} {{DOMException}}.
+5. If [=this=] has no video track, return [=a promise rejected with=] {{InvalidStateError}} {{DOMException}}.
+6. If [=this=]'s {{HTMLVideoElement/disablePictureInPicture}} is true, return [=a promise rejected with=] {{InvalidStateError}} {{DOMException}}.
+7. If |doc|'s [=Picture-in-Picture element=] is `null`:
     1. If [=this=]'s [=relevant global object=] does not have a [=transient activation=], then return [=a
-       promise rejected with=] {{NotAllowedError}} {{DOMException}}
+       promise rejected with=] {{NotAllowedError}} {{DOMException}}.
     2. [=Consume user activation=] given [=this=]'s [=relevant global object=].
-7. If [=this=] is {{pictureInPictureElement}}:
-    1. Return [=a promise resolved with=] the [=Picture-in-Picture window=] associated with {{pictureInPictureElement}}.
-8. Let |global| be [=this=]'s [=relevant global object=].
-9. Let |p| be [=a new promise=] created in [=this=]'s [=relevant realm=].
-10. Return |p|, and [=enqueue the following steps=] to [=this=]'s [=node document=]'s [=picture-in-picture parallel queue=]:
-    1. If [=this=] is {{pictureInPictureElement}}:
+8. If [=this=] is |doc|'s [=Picture-in-Picture element=]:
+    1. Return [=a promise resolved with=] the [=Picture-in-Picture window=] associated with |doc|'s [=Picture-in-Picture element=].
+9. Let |global| be [=this=]'s [=relevant global object=].
+10. Let |p| be [=a new promise=] created in [=this=]'s [=relevant realm=].
+11. Return |p|, and [=enqueue the following steps=] to |doc|'s [=picture-in-picture parallel queue=]:
+    1. If [=this=] is |doc|'s [=Picture-in-Picture element=]:
         1. [=Queue a global task=] on the [=media element event task source=] given |global| to
             [=/resolve=] |p| with the [=Picture-in-Picture window=] associated with
             [=this=].
@@ -340,15 +342,15 @@ The {{requestPictureInPicture()}} method steps <dfn>request Picture-in-Picture</
     4. Let |pipWindow| be a new instance of {{PictureInPictureWindow}} that represents [=this=]'s associated [=Picture-in-Picture window=].
     5. [=Queue a global task=] on the [=media element event task source=] given |global|, to perform
         the following steps:
-        1. Set [=this=]'s [=node document=]'s [=Picture-in-Picture element=] to [=this=].
+        1. Set |doc|'s [=Picture-in-Picture element=] to [=this=].
         2. [=list/Append=] [=relevant settings object=]'s [=origin=] to [=initiators of active
             Picture-in-Picture sessions=].
         3. If [=this=] is [=fullscreenElement=], [=exit fullscreen=].
-        4. [=Fire an event=] named {{enterpictureinpicture}} using {{PictureInPictureEvent}} at the
+        4. [=Fire an event=] named {{enterpictureinpicture}} using {{PictureInPictureEvent}} at
             [=this=] with its {{bubbles}} attribute initialized to `true` and its
             {{PictureInPictureEvent/pictureInPictureWindow}} attribute initialized to
             [=Picture-in-Picture window=].
-        5. [=/Resolve=] |p| with the |pipWindow|
+        5. [=/Resolve=] |p| with |pipWindow|.
 
 
 ## Extensions to <code>Document</code> ## {#document-extensions}
@@ -475,8 +477,8 @@ regardless of the <a>browsing context</a>.
 ## Permissions Policy ## {#permissions-policy}
 
 This specification defines a <a>policy-controlled feature</a> named
-`"picture-in-picture"` that controls whether the <a>request Picture-in-Picture
-algorithm</a> may return a {{SecurityError}} and whether
+`"picture-in-picture"` that controls whether [=request Picture-in-Picture=]
+may return a {{SecurityError}} and whether
 {{pictureInPictureEnabled}} is `true` or `false`.
 
 The <a>default allowlist</a> for this feature is `*`.

--- a/index.bs
+++ b/index.bs
@@ -176,7 +176,7 @@ to initiate and control this behavior by exposing the following sets of properti
 
 A <dfn>Picture-in-Picture window</dfn> is a window displaying the video element.
 
-A <a>Document</a> has:
+A <a>DocumentOrShadowRoot</a> has:
 
 1. A <dfn>Picture-in-Picture element</dfn>, which is an {{Element}} or null, initially null.
 
@@ -340,25 +340,23 @@ The {{requestPictureInPicture()}} method steps are:
             [=/resolve=] |p| with the [=Picture-in-Picture window=] associated with
             [=this=].
         2. Abort these steps.
-    2. Attempt to associate a [=Picture in Picture window=] with [=this=].
+    2. Attempt to associate a [=Picture-in-Picture window=] with [=this=].
     3. If the previous step failed:
         1. [=Queue a global task=] on the [=media element event task source=] given |global| to
             [=/reject=] |p| with {{InvalidStateError}} {{DOMException}}.
         2. Abort these steps.
     4. Let |pipWindow| be new instance of {{PictureInPictureWindow}} that represents [=this=]'s associated [=Picture-in-Picture window=].
-    4. [=Queue a global task=] on the [=media element event task source=] given |global|, to perform
+    5. [=Queue a global task=] on the [=media element event task source=] given |global|, to perform
         the following steps:
         1. Set [=this=]'s [=node document=]'s [=Picture-in-Picture element=] to [=this=].
         2. [=list/Append=] [=relevant settings object=]'s [=origin=] to [=initiators of active
             Picture-in-Picture sessions=].
-        3. If [=this=] is [=fullscreenElement=], it is RECOMMENDED to [=exit
-           fullscreen=].
+        3. If [=this=] is [=fullscreenElement=], [=exit fullscreen=].
         4. [=Fire an event=] named {{enterpictureinpicture}} using {{PictureInPictureEvent}} at the
             [=this=] with its {{bubbles}} attribute initialized to `true` and its
             {{PictureInPictureEvent/pictureInPictureWindow}} attribute initialized to
             [=Picture-in-Picture window=].
-        5. [=/Resolve=] |p| with the [=Picture-in-Picture window=] associated with
-            [=this=].
+        5. [=/Resolve=] |p| with the |pipWindow|
 
 
 ## Extensions to <code>Document</code> ## {#document-extensions}

--- a/index.bs
+++ b/index.bs
@@ -319,7 +319,7 @@ The {{requestPictureInPicture()}} method steps <dfn export>request Picture-in-Pi
     named `"picture-in-picture"`, return [=a promise rejected with=] {{NotAllowedError}} {{DOMException}}.
 4. If [=this=]'s {{readyState}} attribute is {{HAVE_NOTHING}}, return [=a promise rejected with=] {{InvalidStateError}} {{DOMException}}.
 5. If [=this=] has no video track, return [=a promise rejected with=] {{InvalidStateError}} {{DOMException}}.
-6. If [=this=]'s {{HTMLVideoElement/disablePictureInPicture}} is true, user agent MAY return [=a promise rejected with=] {{InvalidStateError}} {{DOMException}}.
+6. If [=this=]'s {{HTMLVideoElement/disablePictureInPicture}} is true, user agent may return [=a promise rejected with=] {{InvalidStateError}} {{DOMException}}.
 7. If |doc|'s [=Picture-in-Picture element=] is `null`:
     1. If [=this=]'s [=relevant global object=] does not have a [=transient activation=], then return [=a
        promise rejected with=] {{NotAllowedError}} {{DOMException}}.

--- a/index.bs
+++ b/index.bs
@@ -171,7 +171,7 @@ to initiate and control this behavior by exposing the following sets of properti
 
 A <dfn>Picture-in-Picture window</dfn> is a window displaying the video element.
 
-A <a>DocumentOrShadowRoot</a> has:
+A {{DocumentOrShadowRoot}} has:
 
 1. A <dfn>Picture-in-Picture element</dfn>, which is an {{Element}} or `null`, initially `null`.
 

--- a/index.bs
+++ b/index.bs
@@ -326,7 +326,7 @@ The {{requestPictureInPicture()}} method steps are:
        promise rejected with=] {{NotAllowedError}} {{DOMException}}
     2. [=Consume user activation=] given [=this=]'s [=relevant global object=].
 7. If [=this=] is {{pictureInPictureElement}}:
-    1. Return [=a promise resolved with=] with the [=Picture-in-Picture window=] associated with {{pictureInPictureElement}}.
+    1. Return [=a promise resolved with=] the [=Picture-in-Picture window=] associated with {{pictureInPictureElement}}.
 8. Let |global| be [=this=]'s [=relevant global object=].
 9. Let |p| be [=a new promise=] created in [=this=]'s [=relevant realm=].
 10. Return |p|, and [=enqueue the following steps=] to [=this=]'s [=node document=]'s [=picture-in-picture parallel queue=]:

--- a/index.bs
+++ b/index.bs
@@ -178,14 +178,15 @@ A <a>Document</a> has:
 
 1. A <dfn>Picture-in-Picture element</dfn>, which is an {{Element}} or null, initially null.
 
+2. A <dfn>picture-in-picture parallel queue</dfn> (a [=parallel queue=]), initially the result of
+    [=starting a new parallel queue=].
+
 A <a>user agent</a> has:
 
 1. An <dfn>initiators of active Picture-in-Picture sessions</dfn>
     list of zero or more <a>origins</a>, which is initially empty.
 
     Note: In case a <a>user agent</a> supports multiple Picture-in-Picture windows, the list allows duplicates.
-2. A <dfn>picture-in-picture parallel queue</dfn> (a [=parallel queue=]), initially the result of
-    [=starting a new parallel queue=].
 
 An origin is said to have an active Picture-in-Picture session if any
 of the origins in <a>initiators of active Picture-in-Picture sessions</a>
@@ -330,7 +331,7 @@ The {{requestPictureInPicture()}} method steps are:
     1. Return [=a promise resolved with=] with the [=Picture-in-Picture window=] associated with {{pictureInPictureElement}}
 8. Let |global| be [=this=]'s [=relevant global object=].
 9. Let |p| be [=a new promise=] created in [=this=]'s [=relevant realm=].
-10. Return |p|, and [=enqueue the following steps=] to the [=user agent=]'s [=picture-in-picture parallel queue=]:
+10. Return |p|, and [=enqueue the following steps=] to [=this=]'s [=node document=]'s [=picture-in-picture parallel queue=]:
     1. If [=this=] is {{pictureInPictureElement}}:
         1. Queue a global task on the [=media element event task source=] given |global| to
             [=/resolve=] |p| with the [=Picture-in-Picture window=] associated with

--- a/index.bs
+++ b/index.bs
@@ -317,7 +317,7 @@ The {{requestPictureInPicture()}} method steps are:
 1. If [=Picture-in-Picture support=] is `false`, return [=a promise rejected with=] {{NotSupportedError}} {{DOMException}}.
 2. If [=this=]'s [=node document=] is not [=allowed to use=] the [=policy-controlled feature=]
     named `"picture-in-picture"`, return [=a promise rejected with=] {{SecurityError}} {{DOMException}}.
-3. If [=this=]'s {{readyState}} attribute is {{HAVE_NOTHING}}, return [=a promise rejected with=] with {{InvalidStateError}} {{DOMException}}
+3. If [=this=]'s {{readyState}} attribute is {{HAVE_NOTHING}}, return [=a promise rejected with=] {{InvalidStateError}} {{DOMException}}
 4. If [=this=] has no video track, return [=a promise rejected with=] {{InvalidStateError}} {{DOMException}}.
 5. If [=this=]'s {{HTMLVideoElement/disablePictureInPicture}} is true, the user agent MAY return [=a
    promise rejected with=] {{InvalidStateError}} {{DOMException}}.

--- a/index.bs
+++ b/index.bs
@@ -26,11 +26,6 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/multipage/
     type: dfn
         urlPrefix: interaction.html
             text: system visibility state
-    type: dfn
-        urlPrefix: infrastructure.html
-            text: parallel queue
-            text: starting a new parallel queue
-            text: enqueue the following steps
 spec: Fullscreen; urlPrefix: https://fullscreen.spec.whatwg.org
     type: dfn; text: fullscreen flag; url: #fullscreen-flag
     type: dfn; text: fullscreenElement; url: dom-document-fullscreenelement

--- a/index.bs
+++ b/index.bs
@@ -319,7 +319,7 @@ The {{requestPictureInPicture()}} method steps <dfn export>request Picture-in-Pi
     named `"picture-in-picture"`, return [=a promise rejected with=] {{NotAllowedError}} {{DOMException}}.
 4. If [=this=]'s {{readyState}} attribute is {{HAVE_NOTHING}}, return [=a promise rejected with=] {{InvalidStateError}} {{DOMException}}.
 5. If [=this=] has no video track, return [=a promise rejected with=] {{InvalidStateError}} {{DOMException}}.
-6. If [=this=]'s {{HTMLVideoElement/disablePictureInPicture}} is true, return [=a promise rejected with=] {{InvalidStateError}} {{DOMException}}.
+6. If [=this=]'s {{HTMLVideoElement/disablePictureInPicture}} is true, user agent MAY return [=a promise rejected with=] {{InvalidStateError}} {{DOMException}}.
 7. If |doc|'s [=Picture-in-Picture element=] is `null`:
     1. If [=this=]'s [=relevant global object=] does not have a [=transient activation=], then return [=a
        promise rejected with=] {{NotAllowedError}} {{DOMException}}.

--- a/index.bs
+++ b/index.bs
@@ -173,7 +173,7 @@ A <dfn>Picture-in-Picture window</dfn> is a window displaying the video element.
 
 A <a>DocumentOrShadowRoot</a> has:
 
-1. A <dfn>Picture-in-Picture element</dfn>, which is an {{Element}} or null, initially null.
+1. A <dfn>Picture-in-Picture element</dfn>, which is an {{Element}} or `null`, initially `null`.
 
 2. A <dfn>picture-in-picture parallel queue</dfn> is a [=parallel queue=] resulting from
     [=starting a new parallel queue=].
@@ -312,15 +312,14 @@ partial interface HTMLVideoElement {
 };
 </pre>
 
-The {{requestPictureInPicture()}} method steps are:
+The {{requestPictureInPicture()}} method steps <dfn>request Picture-in-Picture</dfn>:
 
 1. If [=Picture-in-Picture support=] is `false`, return [=a promise rejected with=] {{NotSupportedError}} {{DOMException}}.
 2. If [=this=]'s [=node document=] is not [=allowed to use=] the [=policy-controlled feature=]
     named `"picture-in-picture"`, return [=a promise rejected with=] {{SecurityError}} {{DOMException}}.
 3. If [=this=]'s {{readyState}} attribute is {{HAVE_NOTHING}}, return [=a promise rejected with=] {{InvalidStateError}} {{DOMException}}
 4. If [=this=] has no video track, return [=a promise rejected with=] {{InvalidStateError}} {{DOMException}}.
-5. If [=this=]'s {{HTMLVideoElement/disablePictureInPicture}} is true, the user agent MAY return [=a
-   promise rejected with=] {{InvalidStateError}} {{DOMException}}.
+5. If [=this=]'s {{HTMLVideoElement/disablePictureInPicture}} is true, return [=a promise rejected with=] {{InvalidStateError}} {{DOMException}}.
 6. If {{pictureInPictureElement}} is `null`:
     1. If [=this=]'s [=relevant global object=] does not have a [=transient activation=], then return [=a
        promise rejected with=] {{NotAllowedError}} {{DOMException}}
@@ -340,7 +339,7 @@ The {{requestPictureInPicture()}} method steps are:
         1. [=Queue a global task=] on the [=media element event task source=] given |global| to
             [=/reject=] |p| with {{InvalidStateError}} {{DOMException}}.
         2. Abort these steps.
-    4. Let |pipWindow| be new instance of {{PictureInPictureWindow}} that represents [=this=]'s associated [=Picture-in-Picture window=].
+    4. Let |pipWindow| be a new instance of {{PictureInPictureWindow}} that represents [=this=]'s associated [=Picture-in-Picture window=].
     5. [=Queue a global task=] on the [=media element event task source=] given |global|, to perform
         the following steps:
         1. Set [=this=]'s [=node document=]'s [=Picture-in-Picture element=] to [=this=].

--- a/index.bs
+++ b/index.bs
@@ -177,7 +177,7 @@ A <a>DocumentOrShadowRoot</a> has:
 
 A <a for="/">traversable navigable</a> has:
 1. A <dfn>picture-in-picture parallel queue</dfn>, which is a [=parallel queue=] created by
-   [=starting a new parallel queue=].
+    [=starting a new parallel queue=].
 
 
 A <a>user agent</a> has:
@@ -192,9 +192,6 @@ of the origins in <a>initiators of active Picture-in-Picture sessions</a>
 are <a>same origin-domain</a> with origin.
 
 ## Picture-in-Picture ## {#pip}
-
-To enter picture-in-picture is to have script invoke
-{{HTMLVideoElement/requestPictureInPicture()}}.
 
 It is RECOMMENDED that video frames are not rendered in the page and in the
 Picture-in-Picture window at the same time but if they are, they MUST be kept

--- a/index.bs
+++ b/index.bs
@@ -172,7 +172,9 @@ to initiate and control this behavior by exposing the following sets of properti
 
 # Concepts # {#concepts}
 
-## Internal Slot Definitions ## {#defines}
+## Definitions ## {#defines}
+
+A <dfn>Picture-in-Picture window</dfn> is a window displaying the video element.
 
 A <a>Document</a> has:
 
@@ -180,6 +182,7 @@ A <a>Document</a> has:
 
 2. A <dfn>picture-in-picture parallel queue</dfn> (a [=parallel queue=]), initially the result of
     [=starting a new parallel queue=].
+
 
 A <a>user agent</a> has:
 
@@ -320,7 +323,7 @@ The {{requestPictureInPicture()}} method steps are:
 2. If [=this=]'s [=node document=] is not [=allowed to use=] the [=policy-controlled feature=]
     named `"picture-in-picture"`, return [=a promise rejected with=] {{SecurityError}} {{DOMException}}.
 3. If [=this=]'s {{readyState}} attribute is {{HAVE_NOTHING}}, return [=a promise rejected with=] with {{InvalidStateError}} {{DOMException}}
-4. If [=this=] has no video track, return [=a promise rejected with=] {{InvalidStateError}} {{DOMException}}
+4. If [=this=] has no video track, return [=a promise rejected with=] {{InvalidStateError}} {{DOMException}}.
 5. If [=this=]'s {{HTMLVideoElement/disablePictureInPicture}} is true, the user agent MAY return [=a
    promise rejected with=] {{InvalidStateError}} {{DOMException}}.
 6. If {{pictureInPictureElement}} is `null`:
@@ -328,36 +331,34 @@ The {{requestPictureInPicture()}} method steps are:
        promise rejected with=] {{NotAllowedError}} {{DOMException}}
     2. [=Consume user activation=] given [=this=]'s [=relevant global object=].
 7. If [=this=] is {{pictureInPictureElement}}:
-    1. Return [=a promise resolved with=] with the [=Picture-in-Picture window=] associated with {{pictureInPictureElement}}
+    1. Return [=a promise resolved with=] with the [=Picture-in-Picture window=] associated with {{pictureInPictureElement}}.
 8. Let |global| be [=this=]'s [=relevant global object=].
 9. Let |p| be [=a new promise=] created in [=this=]'s [=relevant realm=].
 10. Return |p|, and [=enqueue the following steps=] to [=this=]'s [=node document=]'s [=picture-in-picture parallel queue=]:
     1. If [=this=] is {{pictureInPictureElement}}:
         1. Queue a global task on the [=media element event task source=] given |global| to
             [=/resolve=] |p| with the [=Picture-in-Picture window=] associated with
-            {{pictureInPictureElement}}
-        2. abort these steps
-    2. Let <dfn>Picture-in-Picture window</dfn> be a new instance of {{PictureInPictureWindow}}
-        associated with [=this=].
-
-        Note: A user agent may abort when it deems necessary, e.g. due to an error.
-    3. In case where user agent aborted:
+            [=this=].
+        2. Abort these steps.
+    2. Attempt to associate a [=Picture in Picture window=] with [=this=].
+    3. If the previous step failed:
         1. [=Queue a global task=] on the [=media element event task source=] given |global| to
-            [=/reject=] |p| with {{InvalidStateError}} {{DOMException}}
-        2. abort these steps
+            [=/reject=] |p| with {{InvalidStateError}} {{DOMException}}.
+        2. Abort these steps.
+    4. Let |pipWindow| be new instance of {{PictureInPictureWindow}} that represents [=this=]'s associated [=Picture-in-Picture window=].
     4. [=Queue a global task=] on the [=media element event task source=] given |global|, to perform
         the following steps:
         1. Set [=this=]'s [=node document=]'s [=Picture-in-Picture element=] to [=this=].
         2. [=list/Append=] [=relevant settings object=]'s [=origin=] to [=initiators of active
             Picture-in-Picture sessions=].
-        3. If {{pictureInPictureElement}} is [=fullscreenElement=], it is RECOMMENDED to [=exit
+        3. If [=this=] is [=fullscreenElement=], it is RECOMMENDED to [=exit
            fullscreen=].
         4. [=Fire an event=] named {{enterpictureinpicture}} using {{PictureInPictureEvent}} at the
             [=this=] with its {{bubbles}} attribute initialized to `true` and its
             {{PictureInPictureEvent/pictureInPictureWindow}} attribute initialized to
             [=Picture-in-Picture window=].
         5. [=/Resolve=] |p| with the [=Picture-in-Picture window=] associated with
-            {{pictureInPictureElement}}.
+            [=this=].
 
 
 ## Extensions to <code>Document</code> ## {#document-extensions}

--- a/index.bs
+++ b/index.bs
@@ -393,8 +393,7 @@ The {{pictureInPictureElement}} attribute's getter must run these steps:
 
 1. If <a>this</a> is a <a for=/>shadow root</a> and its <a for=DocumentFragment>host</a>
     is not <a>connected</a>, return `null` and abort these steps.
-2. Let |candidate| be the result of <a>retargeting</a> <a>Picture-in-Picture element</a>
-    against <a>this</a>.
+2. Let |candidate| be the result of [=retargeting=] [=Picture-in-Picture element=] against [=this=].
 3. If |candidate| and <a>this</a> are in the same <a>tree</a>,
     return |candidate| and abort these steps.
 4. Return `null`.

--- a/index.bs
+++ b/index.bs
@@ -479,7 +479,7 @@ regardless of the <a>browsing context</a>.
 
 This specification defines a <a>policy-controlled feature</a> named
 `"picture-in-picture"` that controls whether [=request Picture-in-Picture=]
-may return a {{SecurityError}} and whether
+returns a {{SecurityError}} and whether
 {{pictureInPictureEnabled}} is `true` or `false`.
 
 The <a>default allowlist</a> for this feature is `*`.

--- a/index.bs
+++ b/index.bs
@@ -331,7 +331,7 @@ The {{requestPictureInPicture()}} method steps are:
 9. Let |p| be [=a new promise=] created in [=this=]'s [=relevant realm=].
 10. Return |p|, and [=enqueue the following steps=] to [=this=]'s [=node document=]'s [=picture-in-picture parallel queue=]:
     1. If [=this=] is {{pictureInPictureElement}}:
-        1. Queue a global task on the [=media element event task source=] given |global| to
+        1. [=Queue a global task=] on the [=media element event task source=] given |global| to
             [=/resolve=] |p| with the [=Picture-in-Picture window=] associated with
             [=this=].
         2. Abort these steps.

--- a/index.bs
+++ b/index.bs
@@ -170,7 +170,7 @@ to initiate and control this behavior by exposing the following sets of properti
 
 ## Definitions ## {#defines}
 
-A <dfn>Picture-in-Picture window</dfn> is a window displaying the video element.
+A <dfn>Picture-in-Picture window</dfn> is a window displaying the <{video}> element.
 
 A {{DocumentOrShadowRoot}} has:
 

--- a/index.bs
+++ b/index.bs
@@ -342,15 +342,16 @@ The {{requestPictureInPicture()}} method steps <dfn export>request Picture-in-Pi
     4. Let |pipWindow| be a new instance of {{PictureInPictureWindow}} that represents [=this=]'s associated [=Picture-in-Picture window=].
     5. [=Queue a global task=] on the [=media element event task source=] given |global|, to perform
         the following steps:
-        1. Set |doc|'s [=Picture-in-Picture element=] to [=this=].
-        2. [=list/Append=] [=relevant settings object=]'s [=origin=] to [=initiators of active
+        1. If {{pictureInPictureElement}} is not `null`, run the [=exit Picture-in-Picture algorithm=].
+        2. Set |doc|'s [=Picture-in-Picture element=] to [=this=].
+        3. [=list/Append=] [=relevant settings object=]'s [=origin=] to [=initiators of active
             Picture-in-Picture sessions=].
-        3. If [=this=] is [=fullscreenElement=], [=exit fullscreen=].
-        4. [=Fire an event=] named {{enterpictureinpicture}} using {{PictureInPictureEvent}} at
+        4. If [=this=] is [=fullscreenElement=], [=exit fullscreen=].
+        5. [=Fire an event=] named {{enterpictureinpicture}} using {{PictureInPictureEvent}} at
             [=this=] with its {{bubbles}} attribute initialized to `true` and its
             {{PictureInPictureEvent/pictureInPictureWindow}} attribute initialized to
             [=Picture-in-Picture window=].
-        5. [=/Resolve=] |p| with |pipWindow|.
+        6. [=/Resolve=] |p| with |pipWindow|.
 
 
 ## Extensions to <code>Document</code> ## {#document-extensions}

--- a/index.bs
+++ b/index.bs
@@ -175,8 +175,9 @@ A <a>DocumentOrShadowRoot</a> has:
 
 1. A <dfn>Picture-in-Picture element</dfn>, which is an {{Element}} or `null`, initially `null`.
 
-2. A <dfn>picture-in-picture parallel queue</dfn> is a [=parallel queue=] resulting from
-    [=starting a new parallel queue=].
+A <a for="/">traversable navigable</a> has:
+1. A <dfn>picture-in-picture parallel queue</dfn>, which is a [=parallel queue=] created by
+   [=starting a new parallel queue=].
 
 
 A <a>user agent</a> has:

--- a/index.bs
+++ b/index.bs
@@ -175,7 +175,7 @@ A <a>DocumentOrShadowRoot</a> has:
 
 1. A <dfn>Picture-in-Picture element</dfn>, which is an {{Element}} or null, initially null.
 
-2. A <dfn>picture-in-picture parallel queue</dfn> (a [=parallel queue=]), initially the result of
+2. A <dfn>picture-in-picture parallel queue</dfn> is a [=parallel queue=] resulting from
     [=starting a new parallel queue=].
 
 


### PR DESCRIPTION
Closes #244
Closes #233
Closes #229 

The idea with the change is to have the step creating the PiP window in parallel:

Let Picture-in-Picture window be a new instance of PictureInPictureWindow associated with pictureInPictureElement.

And only after that, queueing the global task that does DOM mutations and what not. Because this creation of the Picture-in-picture can theoretically take forever.

This addresses the issues (and the WIP laid out there) in #244 which points out in-parallel mutation of the DOM and resolving promises when it can't.

I think this model fits what Chrome does already and being the one implementing this in Firefox, I feel comfortable with claiming it's achievable in some form there too.

cc @zcorpan && @beaufortfrancois - leaving PR to start discussion.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/theIDinside/picture-in-picture/pull/245.html" title="Last updated on May 10, 2026, 1:45 PM UTC (e4a9306)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/picture-in-picture/245/2983289...theIDinside:e4a9306.html" title="Last updated on May 10, 2026, 1:45 PM UTC (e4a9306)">Diff</a>