### PR TITLE
Consume user activation when requesting PiP

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -197,9 +197,10 @@ the user agent MUST run the following steps:
     these steps.
 5. If |video|'s {{HTMLVideoElement/disablePictureInPicture}} is true,
     the user agent MAY throw an {{InvalidStateError}} and abort these steps.
-6. If {{pictureInPictureElement}} is `null` and the <a>relevant global object</a>
-    of <a>this</a> does not have <a>transient activation</a>, throw a
-    {{NotAllowedError}} and abort these steps.
+6. If {{pictureInPictureElement}} is `null`:
+    1. If <a>this</a>'s <a>relevant global object</a> does not have 
+        <a>transient activation</a>, throw a {{NotAllowedError}} and abort these steps.
+    2. [=Consume user activation=] given <a>this</a>'s <a>relevant global object</a>.
 7. If |video| is {{pictureInPictureElement}}, abort these steps.
 8. Set {{pictureInPictureElement}} to |video|.
 9. Let <dfn>Picture-in-Picture window</dfn> be a new instance of


### PR DESCRIPTION
Raised in https://github.com/w3c/picture-in-picture/pull/245#issuecomment-3944953154, this PR adds missing "Consume user activation when requesting PiP" as tested in [Web Platform Tests](https://github.com/web-platform-tests/wpt/blob/dad7cb2f11d8f79d0861f313fd0a930d85763f04/picture-in-picture/request-picture-in-picture-twice.html#L17).

@theIDinside @marcoscaceres


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/picture-in-picture/pull/246.html" title="Last updated on Feb 23, 2026, 2:44 PM UTC (16fd99e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/picture-in-picture/246/f3ef898...16fd99e.html" title="Last updated on Feb 23, 2026, 2:44 PM UTC (16fd99e)">Diff</a>