### PR TITLE
pictureInPictureElement algorithm fix

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -391,12 +391,16 @@ partial interface mixin DocumentOrShadowRoot {
 
 The {{pictureInPictureElement}} attribute's getter must run these steps:
 
-1. If <a>this</a> is a <a for=/>shadow root</a> and its <a for=DocumentFragment>host</a>
-    is not <a>connected</a>, return `null` and abort these steps.
-2. Let |candidate| be the result of [=retargeting=] [=Picture-in-Picture element=] against [=this=].
-3. If |candidate| and <a>this</a> are in the same <a>tree</a>,
-    return |candidate| and abort these steps.
-4. Return `null`.
+1. If [=this=] is a <a for=/>shadow root</a> and its <a for=DocumentFragment>host</a>
+    is not <a>connected</a>, return `null`.
+2. Let |candidate| be the result of <a>retargeting</a> Picture-in-Picture
+    element against [=this=].
+3. If |candidate| is `null`, return `null`.
+4. If |candidate| and [=this=] are in the same [=tree=],
+    return |candidate|.
+5. If [=this=] is a {{Document}} and |candidate|'s [=node document=]
+    is [=this=], return |candidate|.
+6. Return `null`.
 
 ## Interface <code>PictureInPictureWindow</code> ## {#interface-picture-in-picture-window}
 

--- a/index.bs
+++ b/index.bs
@@ -400,14 +400,14 @@ The {{pictureInPictureElement}} attribute's getter must run these steps:
     return |candidate|.
 5. If [=this=] is a {{Document}} and |candidate|'s [=node document=]
     is [=this=], return |candidate|.
-6. Return `null`.
 
-Note: Step 5 handles the case where |candidate| is not <a>connected</a> to
-<a>this</a>'s <a>tree</a> but its <a>node document</a> is still <a>this</a>.
-For example, an element that was created via {{Document/createElement()}}
-but never inserted into the tree. In that case |candidate| and <a>this</a>
-are not in the same <a>tree</a> (so step 4 does not match), but the element
-still belongs to <a>this</a> Document and is returned to script.
+    Note: This handles the case where |candidate| is not [=connected=] to
+    [=this=]'s [=tree=] but its [=node document=] is still [=this=].
+    For example, an element that was created via {{Document/createElement()}}
+    but never inserted into the tree. In that case |candidate| and [=this=]
+    are not in the same [=tree=] (so step 4 does not match), but the element
+    still belongs to [=this=] Document and is returned to script.
+6. Return `null`.
 
 ## Interface <code>PictureInPictureWindow</code> ## {#interface-picture-in-picture-window}
 

--- a/index.bs
+++ b/index.bs
@@ -402,6 +402,13 @@ The {{pictureInPictureElement}} attribute's getter must run these steps:
     is [=this=], return |candidate|.
 6. Return `null`.
 
+Note: Step 5 handles the case where |candidate| is not <a>connected</a> to
+<a>this</a>'s <a>tree</a> but its <a>node document</a> is still <a>this</a>.
+For example, an element that was created via {{Document/createElement()}}
+but never inserted into the tree. In that case |candidate| and <a>this</a>
+are not in the same <a>tree</a> (so step 4 does not match), but the element
+still belongs to <a>this</a> Document and is returned to script.
+
 ## Interface <code>PictureInPictureWindow</code> ## {#interface-picture-in-picture-window}
 
 <pre class="idl">


### PR DESCRIPTION
Addresses the issue with the getter algorithm and the behavior that two major browsers have, diverging from spec, when considering unbound/disconnected elements, to be in the same tree as the owner document.

Web platform tests account for this workiing, and as the test page in the issue provides an example that also works in safari.

The counter argument would be; "Why would we want to PIP disconnected elements" and the reason I could think of was, like a dynamic site that removes elements as the user scrolls and what not, and the video should still be playable (and reachable via `document.pictureInPictureElement`).

But the spec algorithm itself, doesn't actually allow for this behavior, without a fix like this one.

@chrisn @marcoscaceres @beaufortfrancois 

Closes #248


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/theIDinside/picture-in-picture/pull/253.html" title="Last updated on May 26, 2026, 9:34 AM UTC (7c6e14b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/picture-in-picture/253/9d88d7b...theIDinside:7c6e14b.html" title="Last updated on May 26, 2026, 9:34 AM UTC (7c6e14b)">Diff</a>