### PR TITLE
Overhaul exit Picture-in-Picture algorithm

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -221,21 +221,32 @@ Picture-in-Picture window.
 
 ## Exit Picture-in-Picture ## {#exit-pip}
 
-When the <dfn>exit Picture-in-Picture algorithm</dfn> is invoked,
-the user agent MUST run the following steps:
+When the <dfn>exit Picture-in-Picture algorithm</dfn> is invoked given |doc| and promise-or-null
+|p|, run these steps:
 
-1. If {{pictureInPictureElement}} is `null`, throw a {{InvalidStateError}} and
-    abort these steps.
-2. Run the <a>close window algorithm</a> with the <a>Picture-in-Picture
-    window</a> associated with {{pictureInPictureElement}}.
-3. <a>Queue a task</a> to <a>fire an event</a> named
-    {{leavepictureinpicture}} using {{PictureInPictureEvent}} at the
-    |video| with its {{bubbles}} attribute initialized to `true` and its
-    {{PictureInPictureEvent/pictureInPictureWindow}} attribute initialized to
-    <a>Picture-in-Picture window</a> associated with {{pictureInPictureElement}}.
-4. Unset {{pictureInPictureElement}}.
-5. Remove one <a>item</a> matching <a>relevant settings object</a>'s <a>origin</a> from
-    <a>initiators of active Picture-in-Picture sessions</a>.
+1. Assert that |doc|'s [=Picture-in-Picture element=] is not `null`.
+2. Assert that these steps are running on the [=picture-in-picture parallel queue=].
+
+    Note: This algorithm is called from {{exitPictureInPicture}} and {{requestPictureInPicture}}.
+    The document unloading steps have to be structured differently due to running on the event loop
+    and can therefore not call this algorithm.
+3. Let |global| be |doc|'s [=relevant global object=].
+4. Run the <a>close window algorithm</a> with the <a>Picture-in-Picture window</a> associated with
+   |doc|'s [=Picture-in-Picture element=].
+5. [=Queue a global task=] on the [=media element event task source=] given |global|, to perform the
+   following steps:
+    1. If |doc|'s [=Picture-in-Picture element=] is `null`:
+        1. [=/Resolve=] |p| if |p| is not `null`.
+        2. Return.
+    2. Let |element| be |doc|'s [=Picture-in-Picture element=].
+    3. Set |doc|'s [=Picture-in-Picture element=] to `null`.
+    4. <a>Fire an event</a> named {{leavepictureinpicture}} using {{PictureInPictureEvent}} at the
+       |element| with its {{bubbles}} attribute initialized to `true` and its
+       {{PictureInPictureEvent/pictureInPictureWindow}} attribute initialized to
+       <a>Picture-in-Picture window</a> associated with |element|.
+    5. Remove one <a>item</a> matching <a>relevant settings object</a>'s <a>origin</a> from
+       <a>initiators of active Picture-in-Picture sessions</a>.
+    6. [=/Resolve=] |p| if |p| is not `null`.
 
 It is NOT RECOMMENDED that the video playback state changes when the <a>exit
 Picture-in-Picture algorithm</a> is invoked. The website SHOULD be in control
@@ -340,18 +351,19 @@ The {{requestPictureInPicture()}} method steps <dfn export>request Picture-in-Pi
             [=/reject=] |p| with {{InvalidStateError}} {{DOMException}}.
         2. Abort these steps.
     4. Let |pipWindow| be a new instance of {{PictureInPictureWindow}} that represents [=this=]'s associated [=Picture-in-Picture window=].
-    5. [=Queue a global task=] on the [=media element event task source=] given |global|, to perform
-        the following steps:
-        1. If {{pictureInPictureElement}} is not `null`, run the [=exit Picture-in-Picture algorithm=].
-        2. Set |doc|'s [=Picture-in-Picture element=] to [=this=].
-        3. [=list/Append=] [=relevant settings object=]'s [=origin=] to [=initiators of active
-            Picture-in-Picture sessions=].
-        4. If [=this=] is [=fullscreenElement=], [=exit fullscreen=].
-        5. [=Fire an event=] named {{enterpictureinpicture}} using {{PictureInPictureEvent}} at
-            [=this=] with its {{bubbles}} attribute initialized to `true` and its
-            {{PictureInPictureEvent/pictureInPictureWindow}} attribute initialized to
-            [=Picture-in-Picture window=].
-        6. [=/Resolve=] |p| with |pipWindow|.
+    5. If |doc|'s [=Picture-in-Picture element=] is not `null`, run the [=exit Picture-in-Picture
+       algorithm=] given |doc| and `null`.
+    6. [=Queue a global task=] on the [=media element event task source=] given |global|, to perform
+       the following steps:
+        1. Set |doc|'s [=Picture-in-Picture element=] to [=this=].
+        2. [=list/Append=] [=relevant settings object=]'s [=origin=] to [=initiators of active
+           Picture-in-Picture sessions=].
+        3. If [=this=] is [=fullscreenElement=], [=exit fullscreen=].
+        4. [=Fire an event=] named {{enterpictureinpicture}} using {{PictureInPictureEvent}} at
+           [=this=] with its {{bubbles}} attribute initialized to `true` and its
+           {{PictureInPictureEvent/pictureInPictureWindow}} attribute initialized to
+           [=Picture-in-Picture window=].
+        5. [=/Resolve=] |p| with |pipWindow|.
 
 
 ## Extensions to <code>Document</code> ## {#document-extensions}
@@ -372,14 +384,19 @@ The {{pictureInPictureEnabled}} attribute's getter must return `true` if
 <dfn>Picture-in-Picture support</dfn> is `false` if there's a user preference
 that disables it or a platform limitation. It is `true` otherwise.
 
-The {{exitPictureInPicture()}} method, when invoked, MUST
-return <a>a new promise</a> |promise| and run the following steps <a>in
-parallel</a>:
+The {{exitPictureInPicture()}} method, when invoked, MUST return <a>a new promise</a> and run the
+following steps:
 
-1. Run the <a>exit Picture-in-Picture algorithm</a>.
-2. If the previous step threw an exception, reject |promise| with that
-    exception and abort these steps.
-3. [=/Resolve=] |promise|.
+1. If [=this=]'s [=Picture-in-Picture element=] is `null`, return [=a promise rejected with=]
+   {{InvalidStateError}} {{DOMException}}.
+2. Let |p| be [=a new promise=] created in [=this=]'s [=relevant realm=].
+3. Return |p|, and [=enqueue the following steps=] to [=this=]'s [=picture-in-picture parallel
+   queue=]:
+    1. If [=this=]'s [=Picture-in-Picture element=] is `null`:
+        1. [=Queue a global task=] on the [=media element event task source=] given [=this=]'s
+           [=relevant global object=] to [=/resolve=] |p|.
+        2. Return.
+    2. Run the <a>exit Picture-in-Picture algorithm</a> given [=this=] and |p|.
 
 ## Extension to <code>DocumentOrShadowRoot</code> ## {#documentorshadowroot-extension}
 

--- a/index.bs
+++ b/index.bs
@@ -221,8 +221,8 @@ Picture-in-Picture window.
 
 ## Exit Picture-in-Picture ## {#exit-pip}
 
-When the <dfn>exit Picture-in-Picture algorithm</dfn> is invoked given |doc| and nullable {{Promise}}
-|p|, run these steps:
+When the <dfn>exit Picture-in-Picture algorithm</dfn> is invoked given |doc| and nullable
+{{Promise}} |p|, run these steps:
 
 1. [=Assert=] that |doc|'s [=Picture-in-Picture element=] is not `null`.
 2. [=Assert=] that these steps are running on the [=picture-in-picture parallel queue=].
@@ -231,7 +231,7 @@ When the <dfn>exit Picture-in-Picture algorithm</dfn> is invoked given |doc| and
     |doc|'s [=Picture-in-Picture element=].
 5. [=Queue a global task=] on the [=media element event task source=] given |global|, to perform the
     following steps:
-    1. If |doc|'s [=Picture-in-Picture element=] is `null`:
+    1. If |doc| is not [=fully active=] or |doc|'s [=Picture-in-Picture element=] is `null`:
         1. If |p| is not `null`, [=/resolve=] |p| with undefined.
         2. Return.
     2. Let |element| be |doc|'s [=Picture-in-Picture element=].
@@ -278,8 +278,12 @@ the user agent MAY run these steps:
 
 ## Interaction with Fullscreen ## {#fullscreen}
 
-It is RECOMMENDED to run the <a>exit Picture-in-Picture algorithm</a> when the
-{{pictureInPictureElement}} <a>fullscreen flag</a> is set.
+It is RECOMMENDED that when a [=Picture-in-Picture element=]'s <a>fullscreen flag</a> is set, the
+user agent runs these steps:
+
+1. Let |doc| be the [=Picture-in-Picture element=]'s [=node document=].
+2. [=Enqueue the following steps=] to |doc|'s <a>picture-in-picture parallel queue</a>:
+    1. Run the <a>exit Picture-in-Picture algorithm</a> given |doc| and `null`.
 
 ## Interaction with Page Visibility ## {#page-visibility}
 
@@ -382,8 +386,8 @@ that disables it or a platform limitation. It is `true` otherwise.
 
 The {{exitPictureInPicture()}} method, when invoked, runs the following steps:
 
-1. If [=this=]'s [=Picture-in-Picture element=] is `null`, return [=a promise rejected with=]
-    {{InvalidStateError}} {{DOMException}}.
+1. If [=this=]'s [=Picture-in-Picture element=] is `null` or [=this=] is not [=fully active=],
+    return [=a promise rejected with=] {{InvalidStateError}} {{DOMException}}.
 2. Let |p| be [=a new promise=] created in [=this=]'s [=relevant realm=].
 3. Return |p|, and [=enqueue the following steps=] to [=this=]'s [=picture-in-picture parallel
     queue=]:

--- a/index.bs
+++ b/index.bs
@@ -236,7 +236,7 @@ When the <dfn>exit Picture-in-Picture algorithm</dfn> is invoked given |doc| and
 5. [=Queue a global task=] on the [=media element event task source=] given |global|, to perform the
     following steps:
     1. If |doc|'s [=Picture-in-Picture element=] is `null`:
-        1. [=/Resolve=] |p| if |p| is not `null`.
+        1. If |p| is not `null`, [=/resolve=] |p| with undefined.
         2. Return.
     2. Let |element| be |doc|'s [=Picture-in-Picture element=].
     3. Set |doc|'s [=Picture-in-Picture element=] to `null`.

--- a/index.bs
+++ b/index.bs
@@ -246,7 +246,7 @@ When the <dfn>exit Picture-in-Picture algorithm</dfn> is invoked given |doc| and
         <a>Picture-in-Picture window</a> associated with |element|.
     5. Remove one <a>item</a> matching <a>relevant settings object</a>'s <a>origin</a> from
         <a>initiators of active Picture-in-Picture sessions</a>.
-    6. [=/Resolve=] |p| if |p| is not `null`.
+    6. If |p| is not `null`, [=/resolve=] |p| with undefined.
 
 It is NOT RECOMMENDED that the video playback state changes when the <a>exit
 Picture-in-Picture algorithm</a> is invoked. The website SHOULD be in control

--- a/index.bs
+++ b/index.bs
@@ -232,20 +232,20 @@ When the <dfn>exit Picture-in-Picture algorithm</dfn> is invoked given |doc| and
     and can therefore not call this algorithm.
 3. Let |global| be |doc|'s [=relevant global object=].
 4. Run the <a>close window algorithm</a> with the <a>Picture-in-Picture window</a> associated with
-   |doc|'s [=Picture-in-Picture element=].
+    |doc|'s [=Picture-in-Picture element=].
 5. [=Queue a global task=] on the [=media element event task source=] given |global|, to perform the
-   following steps:
+    following steps:
     1. If |doc|'s [=Picture-in-Picture element=] is `null`:
         1. [=/Resolve=] |p| if |p| is not `null`.
         2. Return.
     2. Let |element| be |doc|'s [=Picture-in-Picture element=].
     3. Set |doc|'s [=Picture-in-Picture element=] to `null`.
     4. <a>Fire an event</a> named {{leavepictureinpicture}} using {{PictureInPictureEvent}} at the
-       |element| with its {{bubbles}} attribute initialized to `true` and its
-       {{PictureInPictureEvent/pictureInPictureWindow}} attribute initialized to
-       <a>Picture-in-Picture window</a> associated with |element|.
+        |element| with its {{bubbles}} attribute initialized to `true` and its
+        {{PictureInPictureEvent/pictureInPictureWindow}} attribute initialized to
+        <a>Picture-in-Picture window</a> associated with |element|.
     5. Remove one <a>item</a> matching <a>relevant settings object</a>'s <a>origin</a> from
-       <a>initiators of active Picture-in-Picture sessions</a>.
+        <a>initiators of active Picture-in-Picture sessions</a>.
     6. [=/Resolve=] |p| if |p| is not `null`.
 
 It is NOT RECOMMENDED that the video playback state changes when the <a>exit
@@ -352,17 +352,17 @@ The {{requestPictureInPicture()}} method steps <dfn export>request Picture-in-Pi
         2. Abort these steps.
     4. Let |pipWindow| be a new instance of {{PictureInPictureWindow}} that represents [=this=]'s associated [=Picture-in-Picture window=].
     5. If |doc|'s [=Picture-in-Picture element=] is not `null`, run the [=exit Picture-in-Picture
-       algorithm=] given |doc| and `null`.
+        algorithm=] given |doc| and `null`.
     6. [=Queue a global task=] on the [=media element event task source=] given |global|, to perform
-       the following steps:
+        the following steps:
         1. Set |doc|'s [=Picture-in-Picture element=] to [=this=].
         2. [=list/Append=] [=relevant settings object=]'s [=origin=] to [=initiators of active
-           Picture-in-Picture sessions=].
+            Picture-in-Picture sessions=].
         3. If [=this=] is [=fullscreenElement=], [=exit fullscreen=].
         4. [=Fire an event=] named {{enterpictureinpicture}} using {{PictureInPictureEvent}} at
-           [=this=] with its {{bubbles}} attribute initialized to `true` and its
-           {{PictureInPictureEvent/pictureInPictureWindow}} attribute initialized to
-           [=Picture-in-Picture window=].
+            [=this=] with its {{bubbles}} attribute initialized to `true` and its
+            {{PictureInPictureEvent/pictureInPictureWindow}} attribute initialized to
+            [=Picture-in-Picture window=].
         5. [=/Resolve=] |p| with |pipWindow|.
 
 
@@ -388,13 +388,13 @@ The {{exitPictureInPicture()}} method, when invoked, MUST return <a>a new promis
 following steps:
 
 1. If [=this=]'s [=Picture-in-Picture element=] is `null`, return [=a promise rejected with=]
-   {{InvalidStateError}} {{DOMException}}.
+    {{InvalidStateError}} {{DOMException}}.
 2. Let |p| be [=a new promise=] created in [=this=]'s [=relevant realm=].
 3. Return |p|, and [=enqueue the following steps=] to [=this=]'s [=picture-in-picture parallel
-   queue=]:
+    queue=]:
     1. If [=this=]'s [=Picture-in-Picture element=] is `null`:
         1. [=Queue a global task=] on the [=media element event task source=] given [=this=]'s
-           [=relevant global object=] to [=/resolve=] |p|.
+            [=relevant global object=] to [=/resolve=] |p|.
         2. Return.
     2. Run the <a>exit Picture-in-Picture algorithm</a> given [=this=] and |p|.
 

--- a/index.bs
+++ b/index.bs
@@ -358,7 +358,7 @@ The {{requestPictureInPicture()}} method steps <dfn export>request Picture-in-Pi
         1. Set |doc|'s [=Picture-in-Picture element=] to [=this=].
         2. [=list/Append=] [=relevant settings object=]'s [=origin=] to [=initiators of active
             Picture-in-Picture sessions=].
-        3. If [=this=] is [=fullscreenElement=], [=exit fullscreen=].
+        3. If [=this=] is [=fullscreenElement=], then [=exit fullscreen=].
         4. [=Fire an event=] named {{enterpictureinpicture}} using {{PictureInPictureEvent}} at
             [=this=] with its {{bubbles}} attribute initialized to `true` and its
             {{PictureInPictureEvent/pictureInPictureWindow}} attribute initialized to

--- a/index.bs
+++ b/index.bs
@@ -224,12 +224,8 @@ Picture-in-Picture window.
 When the <dfn>exit Picture-in-Picture algorithm</dfn> is invoked given |doc| and nullable {{Promise}}
 |p|, run these steps:
 
-1. Assert that |doc|'s [=Picture-in-Picture element=] is not `null`.
-2. Assert that these steps are running on the [=picture-in-picture parallel queue=].
-
-    Note: This algorithm is called from {{exitPictureInPicture}} and {{requestPictureInPicture}}.
-    The document unloading steps have to be structured differently due to running on the event loop
-    and can therefore not call this algorithm.
+1. [=Assert=] that |doc|'s [=Picture-in-Picture element=] is not `null`.
+2. [=Assert=] that these steps are running on the [=picture-in-picture parallel queue=].
 3. Let |global| be |doc|'s [=relevant global object=].
 4. Run the <a>close window algorithm</a> with the <a>Picture-in-Picture window</a> associated with
     |doc|'s [=Picture-in-Picture element=].

--- a/index.bs
+++ b/index.bs
@@ -221,7 +221,7 @@ Picture-in-Picture window.
 
 ## Exit Picture-in-Picture ## {#exit-pip}
 
-When the <dfn>exit Picture-in-Picture algorithm</dfn> is invoked given |doc| and promise-or-null
+When the <dfn>exit Picture-in-Picture algorithm</dfn> is invoked given |doc| and nullable {{Promise}}
 |p|, run these steps:
 
 1. Assert that |doc|'s [=Picture-in-Picture element=] is not `null`.

--- a/index.bs
+++ b/index.bs
@@ -380,8 +380,7 @@ The {{pictureInPictureEnabled}} attribute's getter must return `true` if
 <dfn>Picture-in-Picture support</dfn> is `false` if there's a user preference
 that disables it or a platform limitation. It is `true` otherwise.
 
-The {{exitPictureInPicture()}} method, when invoked, MUST return <a>a new promise</a> and run the
-following steps:
+The {{exitPictureInPicture()}} method, when invoked, runs the following steps:
 
 1. If [=this=]'s [=Picture-in-Picture element=] is `null`, return [=a promise rejected with=]
     {{InvalidStateError}} {{DOMException}}.

--- a/index.bs
+++ b/index.bs
@@ -221,15 +221,14 @@ Picture-in-Picture window.
 
 ## Exit Picture-in-Picture ## {#exit-pip}
 
-When the <dfn>exit Picture-in-Picture algorithm</dfn> is invoked given |doc| and nullable
+When the <dfn>exit Picture-in-Picture algorithm</dfn> is invoked given |doc|,  and nullable
 {{Promise}} |p|, run these steps:
 
-1. [=Assert=] that |doc|'s [=Picture-in-Picture element=] is not `null`.
-2. [=Assert=] that these steps are running on the [=picture-in-picture parallel queue=].
-3. Let |global| be |doc|'s [=relevant global object=].
-4. Run the <a>close window algorithm</a> with the <a>Picture-in-Picture window</a> associated with
+1. [=Assert=] that these steps are running on the [=picture-in-picture parallel queue=].
+2. Let |global| be |doc|'s [=relevant global object=].
+3. Run the <a>close window algorithm</a> with the <a>Picture-in-Picture window</a> associated with
     |doc|'s [=Picture-in-Picture element=].
-5. [=Queue a global task=] on the [=media element event task source=] given |global|, to perform the
+4. [=Queue a global task=] on the [=media element event task source=] given |global|, to perform the
     following steps:
     1. If |doc| is not [=fully active=] or |doc|'s [=Picture-in-Picture element=] is `null`:
         1. If |p| is not `null`, [=/resolve=] |p| with undefined.
@@ -250,8 +249,16 @@ of the experience if it is website initiated. However, the user agent MAY expose
 Picture-in-Picture window controls that change video playback state (e.g.,
 pause).
 
-As one of the <a>unloading document cleanup steps</a>, run the <a>exit
-Picture-in-Picture algorithm</a>.
+### Unloading steps ### {#unloading-steps}
+As one of the <a>unloading document cleanup steps</a> given |doc| run the following steps:
+1. If |doc|'s [=Picture-in-Picture element=] is `null`, return.
+2. Let |window| be the <a>Picture-in-Picture window</a> associated with |doc|'s
+    [=Picture-in-Picture element=].
+3. Set |doc|'s [=Picture-in-Picture element=] to `null`.
+4. Remove one <a>item</a> matching <a>relevant settings object</a>'s <a>origin</a> from
+    <a>initiators of active Picture-in-Picture sessions</a>.
+5. [=Enqueue the following steps=] to |doc|'s <a>picture-in-picture parallel queue</a>:
+    1. Run the <a>close window algorithm</a> with |window|.
 
 ## Disable Picture-in-Picture ## {#disable-pip}
 


### PR DESCRIPTION
Rework the exit Picture-in-Picture algorithm to mirror the requestPictureInPicture() overhaul (#245):
- run the work on the document's picture-in-picture parallel queue
- perform DOM mutation, promise resolution inside a queued global task
- keep the window close in parallel since closing may be asynchronous/disjoint across implementations.

The algorithm now takes |doc| and a promise-or-null |p| as input arguments.

First commit does not deal with:
- Fixing "unloading document steps". Unfortunately it can not re-use the algorithm, because it runs on the event loop, it needs to mutate DOM stuff and then enqueue work on the parallel queue to close the window.
- disablePictureInPicture must call the new algorithm by enqueing steps, providing input args
- when fullscreen flag is set, it must call the new algorithm by enqueing steps, providing input args

Addresses #252


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/theIDinside/picture-in-picture/pull/260.html" title="Last updated on Jun 29, 2026, 5:08 PM UTC (81e4c56)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/picture-in-picture/260/9d88d7b...theIDinside:81e4c56.html" title="Last updated on Jun 29, 2026, 5:08 PM UTC (81e4c56)">Diff</a>