### PR TITLE
Add Accessibility section

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -478,7 +478,7 @@ subtitles, or an accompanying sign-language or other alternative media track,
 the <a>user agent</a> MUST continue to present it in the Picture-in-Picture
 window, unless the platform's Picture-in-Picture surface makes this impossible.
 
-When Picture-in-Picture is exited, focus MUST return to the element that
+When Picture-in-Picture is exited, focus MUST return to the
 last focused known focused element on the page.
 
 The Picture-in-Picture window itself MAY be provided by the operating system

--- a/index.bs
+++ b/index.bs
@@ -459,12 +459,15 @@ Making Picture-in-Picture accessible is a shared responsibility between the
 
 The <a>user agent</a> is responsible for the parts of the experience it
 controls. When a <a>user agent</a> presents an affordance to enter
-Picture-in-Picture, that affordance MUST be operable by keyboard and MUST expose
-its name, role, state, and value to platform accessibility APIs.
+Picture-in-Picture, that affordance MUST expose its name, role, state, and value
+to platform accessibility APIs and MUST be operable through assistive
+technology. Where the platform supports keyboard input, the affordance MUST be
+keyboard operable.
 
 When the <a>user agent</a> draws controls in the Picture-in-Picture window
-itself, those controls MUST be operable by keyboard and expose their name, role,
-state, and value to platform accessibility APIs. The available controls are
+itself, those controls MUST expose their name, role, state, and value to platform
+accessibility APIs and be operable through assistive technology, including by
+keyboard where the platform supports keyboard input. The available controls are
 customized using the [[MediaSession]] API. Because the play and pause control
 reflects the media's playback state, the <a>user agent</a> MUST convey the
 current play or pause state to assistive technology, for example by updating the

--- a/index.bs
+++ b/index.bs
@@ -479,8 +479,7 @@ the <a>user agent</a> MUST continue to present it in the Picture-in-Picture
 window, unless the platform's Picture-in-Picture surface makes this impossible.
 
 When Picture-in-Picture is exited, focus MUST return to the element that
-initiated Picture-in-Picture, or, if that element is no longer available, to the
-originating video element.
+last focused known focused element on the page.
 
 The Picture-in-Picture window itself MAY be provided by the operating system
 rather than the <a>user agent</a>. Where the platform draws the window and its

--- a/index.bs
+++ b/index.bs
@@ -452,6 +452,41 @@ The `:picture-in-picture` <a>pseudo-class</a> MUST match the Picture-in-Picture
 element. It is different from the {{pictureInPictureElement}} as it does NOT
 apply to the shadow host chain.
 
+# Accessibility # {#accessibility}
+
+Making Picture-in-Picture accessible is a shared responsibility between the
+<a>user agent</a> and the underlying platform.
+
+The <a>user agent</a> is responsible for the parts of the experience it
+controls. When a <a>user agent</a> presents an affordance to enter
+Picture-in-Picture, that affordance MUST be operable by keyboard and MUST expose
+its name, role, state, and value to platform accessibility APIs.
+
+When the <a>user agent</a> draws controls in the Picture-in-Picture window
+itself, those controls MUST be operable by keyboard and expose their name, role,
+state, and value to platform accessibility APIs. The available controls are
+customized using the [[MediaSession]] API. Because the play and pause control
+reflects the media's playback state, the <a>user agent</a> MUST convey the
+current play or pause state to assistive technology, for example by updating the
+control's accessible name or by exposing its pressed state.
+
+When entering Picture-in-Picture, if the video is presenting captions,
+subtitles, or an accompanying sign-language or other alternative media track,
+the <a>user agent</a> MUST continue to present it in the Picture-in-Picture
+window, unless the platform's Picture-in-Picture surface makes this impossible.
+
+When Picture-in-Picture is exited, focus MUST return to the element that
+initiated Picture-in-Picture, or, if that element is no longer available, to the
+originating video element.
+
+The Picture-in-Picture window itself may be provided by the operating system
+rather than the <a>user agent</a>. Where the platform draws the window and its
+controls, the accessibility of that surface, including contrast and keyboard
+operation of system controls, depends on the platform.
+
+Note: [[WCAG22]] defines conformance for web content. The accessibility of the
+<a>user agent</a>'s own user interface is out of scope for this specification.
+
 # Security considerations # {#security-considerations}
 
 <em>This section is non-normative.</em>

--- a/index.bs
+++ b/index.bs
@@ -482,7 +482,7 @@ When Picture-in-Picture is exited, focus MUST return to the element that
 initiated Picture-in-Picture, or, if that element is no longer available, to the
 originating video element.
 
-The Picture-in-Picture window itself may be provided by the operating system
+The Picture-in-Picture window itself MAY be provided by the operating system
 rather than the <a>user agent</a>. Where the platform draws the window and its
 controls, the accessibility of that surface, including contrast and keyboard
 operation of system controls, depends on the platform.


### PR DESCRIPTION
Adds an Accessibility section resolving #179 (raised by the APA WG). It states that accessibility is a shared responsibility between the user agent and the platform, placing requirements on what the user agent controls (the entry affordance, controls it draws, caption and sign-language track rendering, focus return) while treating the OS-drawn Picture-in-Picture surface as a platform dependency, since on some platforms the window is provided by the operating system rather than the browser.

Opening as a draft for APA to confirm the direction resolves their concern before we finalise wording, add WPT coverage, and confirm implementer support. Two sub-threads from the issue (deeper caption-rendering mechanics, and whether Media Session should normatively drive the control set) would be better tracked as their own issues rather than blocking this.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/marcoscaceres/picture-in-picture/pull/264.html" title="Last updated on Jul 30, 2026, 10:56 AM UTC (a163480)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/picture-in-picture/264/1ff6a82...marcoscaceres:a163480.html" title="Last updated on Jul 30, 2026, 10:56 AM UTC (a163480)">Diff</a>